### PR TITLE
feat: broadcast payment creation

### DIFF
--- a/app/Events/PaymentCreated.php
+++ b/app/Events/PaymentCreated.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class PaymentCreated implements ShouldBroadcast
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public $message;
+    public $patient_id;
+    public $created_at;
+
+    public function __construct($message, $patient_id)
+    {
+        $this->message = $message;
+        $this->patient_id = $patient_id;
+        $this->created_at = date('Y-m-d H:i:s');
+    }
+
+    public function broadcastOn()
+    {
+        return [
+            new PrivateChannel('create-payment.admin'),
+            new PrivateChannel('create-payment.patient.' . $this->patient_id),
+        ];
+    }
+
+    public function broadcastAs()
+    {
+        return 'payment-created';
+    }
+
+    public function broadcastWhen()
+    {
+        return \App\Support\Net::online();
+    }
+}

--- a/app/Repository/Finance/PaymentRepository.php
+++ b/app/Repository/Finance/PaymentRepository.php
@@ -8,6 +8,9 @@ use App\Models\Patient;
 use App\Models\PatientAccount;
 use App\Models\PaymentAccount;
 use Illuminate\Support\Facades\DB;
+use App\Models\Notification;
+use App\Models\Admin;
+use App\Events\PaymentCreated;
 
 class PaymentRepository implements PaymentRepositoryInterface
 {
@@ -60,6 +63,22 @@ class PaymentRepository implements PaymentRepositoryInterface
             $patient_accounts->Debit = $request->credit;
             $patient_accounts->credit = 0.00;
             $patient_accounts->save();
+
+            $message = 'تم إضافة سند صرف بقيمة ' . $request->credit;
+
+            Notification::create([
+                'user_id' => $request->patient_id,
+                'message' => $message,
+            ]);
+
+            foreach (Admin::all() as $admin) {
+                Notification::create([
+                    'user_id' => $admin->id,
+                    'message' => $message,
+                ]);
+            }
+
+            event(new PaymentCreated($message, $request->patient_id));
 
             DB::commit();
             session()->flash('add');

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -20,6 +20,7 @@ Broadcast::channel('create-ambulance.admin', fn($user) => auth('admin')->check()
 Broadcast::channel('create-single-service.admin', fn($user) => auth('admin')->check(), ['guards' => ['admin']]);
 Broadcast::channel('create-group-service.admin', fn($user) => auth('admin')->check(), ['guards' => ['admin']]);
 Broadcast::channel('create-patient.admin', fn($user) => auth('admin')->check(), ['guards' => ['admin']]);
+Broadcast::channel('create-payment.admin', fn($user) => auth('admin')->check(), ['guards' => ['admin']]);
 Broadcast::channel(
     'create-invoice.{doctor_id}',
     function ($user, $doctor_id) {
@@ -39,6 +40,14 @@ Broadcast::channel(
 
 Broadcast::channel(
     'create-receipt.patient.{patient_id}',
+    function ($user, $patient_id) {
+        return $user->id == $patient_id;
+    },
+    ['guards' => ['web', 'admin', 'patient', 'doctor', 'ray_employee', 'laboratorie_employee', 'api']]
+);
+
+Broadcast::channel(
+    'create-payment.patient.{patient_id}',
     function ($user, $patient_id) {
         return $user->id == $patient_id;
     },


### PR DESCRIPTION
## Summary
- broadcast PaymentCreated event when a payment is stored
- register payment notification channels for admin and patient
- notify patient and admins on payment creation

## Testing
- `php artisan test` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f7d1ad7483288dcb86641222d071