### PR TITLE
Replace hardcoded Arabic text with translation keys in doctors index

### DIFF
--- a/resources/lang/ar/Doctors.php
+++ b/resources/lang/ar/Doctors.php
@@ -24,4 +24,8 @@ return array (
   'section' => 'القسم',
   'submit' => 'تاكيد',
   'update_password' => 'تغير كلمة المرور',
+  'EditData' => 'تعديل البيانات',
+  'ChangePassword' => 'تغير كلمة المرور',
+  'ChangeStatus' => 'تغير الحالة',
+  'DeleteData' => 'حذف البيانات',
 );

--- a/resources/lang/en/Doctors.php
+++ b/resources/lang/en/Doctors.php
@@ -24,4 +24,8 @@ return array (
   'section' => 'Section',
   'submit' => 'submit',
   'update_password' => 'Update Password',
+  'EditData' => 'Edit Data',
+  'ChangePassword' => 'Change Password',
+  'ChangeStatus' => 'Change Status',
+  'DeleteData' => 'Delete Data',
 );

--- a/resources/views/Dashboard/Doctors/index.blade.php
+++ b/resources/views/Dashboard/Doctors/index.blade.php
@@ -91,10 +91,10 @@
                                         <div class="dropdown">
                                             <button aria-expanded="false" aria-haspopup="true" class="btn ripple btn-outline-primary btn-sm" data-toggle="dropdown" type="button">{{trans('doctors.Processes')}}<i class="fas fa-caret-down mr-1"></i></button>
                                             <div class="dropdown-menu tx-13">
-                                                <a class="dropdown-item" href="{{route('Doctors.edit',$doctor->id)}}"><i style="color: #0ba360" class="text-success ti-user"></i>&nbsp;&nbsp;تعديل البيانات</a>
-                                                <a class="dropdown-item" href="#" data-toggle="modal" data-target="#update_password{{$doctor->id}}"><i   class="text-primary ti-key"></i>&nbsp;&nbsp;تغير كلمة المرور</a>
-                                                <a class="dropdown-item" href="#" data-toggle="modal" data-target="#update_status{{$doctor->id}}"><i   class="text-warning ti-back-right"></i>&nbsp;&nbsp;تغير الحالة</a>
-                                                <a class="dropdown-item" href="#" data-toggle="modal" data-target="#delete{{$doctor->id}}"><i   class="text-danger  ti-trash"></i>&nbsp;&nbsp;حذف البيانات</a>
+                                                <a class="dropdown-item" href="{{route('Doctors.edit',$doctor->id)}}"><i style="color: #0ba360" class="text-success ti-user"></i>&nbsp;&nbsp;{{ trans('Doctors.EditData') }}</a>
+                                                <a class="dropdown-item" href="#" data-toggle="modal" data-target="#update_password{{$doctor->id}}"><i   class="text-primary ti-key"></i>&nbsp;&nbsp;{{ trans('Doctors.ChangePassword') }}</a>
+                                                <a class="dropdown-item" href="#" data-toggle="modal" data-target="#update_status{{$doctor->id}}"><i   class="text-warning ti-back-right"></i>&nbsp;&nbsp;{{ trans('Doctors.ChangeStatus') }}</a>
+                                                <a class="dropdown-item" href="#" data-toggle="modal" data-target="#delete{{$doctor->id}}"><i   class="text-danger  ti-trash"></i>&nbsp;&nbsp;{{ trans('Doctors.DeleteData') }}</a>
                                             </div>
                                         </div>
 


### PR DESCRIPTION
## Summary
- use translation strings for doctor actions menu
- add missing translation keys in Arabic and English locales

## Testing
- `./vendor/bin/phpunit` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ff776fb88328a1daa531c88dcf8d