### PR TITLE
Add appointment creation notification channel

### DIFF
--- a/resources/views/Dashboard/layouts/main-header.blade.php
+++ b/resources/views/Dashboard/layouts/main-header.blade.php
@@ -575,6 +575,23 @@ $channel = auth('doctor')->check()
         notificationsWrapper.show();
     }
 
+    function handleAppointmentCreatedEvent(data) {
+        const text = $('<div>').text(data.message).html();
+        const time = $('<div>').text(data.created_at).html();
+
+        const newNotificationHtml = `
+                <h4 class="notification-label mb-1">${text}</h4>
+                <div class="notification-subtext">${time}</div>`;
+
+        new_message.show();
+        notifications.html(newNotificationHtml);
+        notificationsCount += 1;
+        notificationsCountElem.attr('data-count', notificationsCount);
+        notificationsWrapper.find('.notif-count').text(notificationsCount);
+        updateNotifBadge();
+        notificationsWrapper.show();
+    }
+
     // Subscribe to notifications channel
 
     function subscribeNotifications() {
@@ -598,6 +615,8 @@ $channel = auth('doctor')->check()
                 .listen('.group-service-created', handleGroupServiceCreatedEvent);
             Echo.private('create-patient.admin')
                 .listen('.patient-created', handlePatientCreatedEvent);
+            Echo.private('create-appointment.admin')
+                .listen('.appointment-created', handleAppointmentCreatedEvent);
             @if(auth('admin')->check())
             Echo.private('create-receipt.admin')
                 .listen('.receipt-created', handleReceiptCreatedEvent);
@@ -634,6 +653,7 @@ $channel = auth('doctor')->check()
                 Echo.leave('create-single-service.admin');
                 Echo.leave('create-group-service.admin');
                 Echo.leave('create-patient.admin');
+                Echo.leave('create-appointment.admin');
                 @if(auth('admin')->check())
                 Echo.leave('create-receipt.admin');
                 Echo.leave('create-payment.admin');

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -21,6 +21,7 @@ Broadcast::channel('create-single-service.admin', fn($user) => auth('admin')->ch
 Broadcast::channel('create-group-service.admin', fn($user) => auth('admin')->check(), ['guards' => ['admin']]);
 Broadcast::channel('create-patient.admin', fn($user) => auth('admin')->check(), ['guards' => ['admin']]);
 Broadcast::channel('create-payment.admin', fn($user) => auth('admin')->check(), ['guards' => ['admin']]);
+Broadcast::channel('create-appointment.admin', fn($user) => auth('admin')->check(), ['guards' => ['admin']]);
 Broadcast::channel(
     'create-invoice.{doctor_id}',
     function ($user, $doctor_id) {


### PR DESCRIPTION
## Summary
- register `create-appointment.admin` broadcast channel for admins
- handle appointment created notifications in main header and clean up on offline
- rebuild frontend assets

## Testing
- `npm run dev`
- `php artisan test` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fe43e2448328a05e9d9d5cfbe53a