### PR TITLE
Add diagnosis broadcast event and notifications

### DIFF
--- a/app/Events/DiagnosisCreated.php
+++ b/app/Events/DiagnosisCreated.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class DiagnosisCreated implements ShouldBroadcast
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public $message;
+    public $patient_id;
+    public $doctor_id;
+    public $created_at;
+
+    public function __construct($message, $patient_id, $doctor_id)
+    {
+        $this->message = $message;
+        $this->patient_id = $patient_id;
+        $this->doctor_id = $doctor_id;
+        $this->created_at = date('Y-m-d H:i:s');
+    }
+
+    public function broadcastOn()
+    {
+        return [
+            new PrivateChannel('create-diagnosis.patient.' . $this->patient_id),
+            new PrivateChannel('create-diagnosis.doctor.' . $this->doctor_id),
+        ];
+    }
+
+    public function broadcastAs()
+    {
+        return 'diagnosis-created';
+    }
+
+    public function broadcastWhen()
+    {
+        return \App\Support\Net::online();
+    }
+}

--- a/app/Repository/doctor_dashboard/DiagnosisRepository.php
+++ b/app/Repository/doctor_dashboard/DiagnosisRepository.php
@@ -5,8 +5,10 @@ namespace App\Repository\doctor_dashboard;
 use App\Interfaces\doctor_dashboard\DiagnosisRepositoryInterface;
 use App\Models\Diagnostic;
 use App\Models\Invoice;
+use App\Models\Notification;
 use Illuminate\Support\Facades\DB;
 use Carbon\Carbon;
+use App\Events\DiagnosisCreated;
 
 class DiagnosisRepository implements DiagnosisRepositoryInterface
 {
@@ -28,6 +30,20 @@ class DiagnosisRepository implements DiagnosisRepositoryInterface
             $diagnosis->doctor_id = $request->doctor_id;
             $diagnosis->date = now();
             $diagnosis->save();
+
+            $message = 'تم إضافة تشخيص للمريض رقم ' . $request->patient_id;
+
+            Notification::create([
+                'user_id' => $request->patient_id,
+                'message' => $message,
+            ]);
+
+            Notification::create([
+                'user_id' => $request->doctor_id,
+                'message' => $message,
+            ]);
+
+            event(new DiagnosisCreated($message, $request->patient_id, $request->doctor_id));
 
             DB::commit();
             session()->flash('add');
@@ -61,6 +77,20 @@ class DiagnosisRepository implements DiagnosisRepositoryInterface
             $diagnosis->patient_id = $request->patient_id;
             $diagnosis->doctor_id = $request->doctor_id;
             $diagnosis->save();
+
+            $message = 'تم إضافة مراجعة للمريض رقم ' . $request->patient_id;
+
+            Notification::create([
+                'user_id' => $request->patient_id,
+                'message' => $message,
+            ]);
+
+            Notification::create([
+                'user_id' => $request->doctor_id,
+                'message' => $message,
+            ]);
+
+            event(new DiagnosisCreated($message, $request->patient_id, $request->doctor_id));
 
             DB::commit();
             session()->flash('add');

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -72,6 +72,22 @@ Broadcast::channel(
 );
 
 Broadcast::channel(
+    'create-diagnosis.patient.{patient_id}',
+    function ($user, $patient_id) {
+        return $user->id == $patient_id;
+    },
+    ['guards' => ['web', 'admin', 'patient', 'doctor', 'ray_employee', 'laboratorie_employee', 'api']]
+);
+
+Broadcast::channel(
+    'create-diagnosis.doctor.{doctor_id}',
+    function ($user, $doctor_id) {
+        return $user->id == $doctor_id;
+    },
+    ['guards' => ['web', 'admin', 'patient', 'doctor', 'ray_employee', 'laboratorie_employee', 'api']]
+);
+
+Broadcast::channel(
     'chat.{receiver_id}',
     function (Doctor $user, $receiver_id) {
         return $user->id == $receiver_id;


### PR DESCRIPTION
## Summary
- broadcast diagnosis creation to patient and doctor channels
- notify patient and doctor on diagnosis or review creation

## Testing
- `vendor/bin/phpunit` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b6081520d0832886b36ee1f13f6422