### PR TITLE
feat: add diagnosis created notifications

### DIFF
--- a/resources/views/Dashboard/layouts/main-header.blade.php
+++ b/resources/views/Dashboard/layouts/main-header.blade.php
@@ -609,6 +609,23 @@ $channel = auth('doctor')->check()
         notificationsWrapper.show();
     }
 
+    function handleDiagnosisCreatedEvent(data) {
+        const text = $('<div>').text(data.message).html();
+        const time = $('<div>').text(data.created_at).html();
+
+        const newNotificationHtml = `
+                <h4 class="notification-label mb-1">${text}</h4>
+                <div class="notification-subtext">${time}</div>`;
+
+        new_message.show();
+        notifications.html(newNotificationHtml);
+        notificationsCount += 1;
+        notificationsCountElem.attr('data-count', notificationsCount);
+        notificationsWrapper.find('.notif-count').text(notificationsCount);
+        updateNotifBadge();
+        notificationsWrapper.show();
+    }
+
     // Subscribe to notifications channel
 
     function subscribeNotifications() {
@@ -644,6 +661,8 @@ $channel = auth('doctor')->check()
                 .listen('.receipt-created', handleReceiptCreatedEvent);
             Echo.private('confirm-appointment.doctor.{{ auth('doctor')->id() }}')
                 .listen('.appointment-confirmed', handleAppointmentConfirmedEvent);
+            Echo.private('create-diagnosis.doctor.{{ auth('doctor')->id() }}')
+                .listen('.diagnosis-created', handleDiagnosisCreatedEvent);
             @elseif(auth('patient')->check())
             Echo.private('create-receipt.patient.{{ auth('patient')->id() }}')
                 .listen('.receipt-created', handleReceiptCreatedEvent);
@@ -651,6 +670,8 @@ $channel = auth('doctor')->check()
                 .listen('.payment-created', handlePaymentCreatedEvent);
             Echo.private('confirm-appointment.patient.{{ auth('patient')->id() }}')
                 .listen('.appointment-confirmed', handleAppointmentConfirmedEvent);
+            Echo.private('create-diagnosis.patient.{{ auth('patient')->id() }}')
+                .listen('.diagnosis-created', handleDiagnosisCreatedEvent);
             @endif
         } catch (e) {
             /* noop */
@@ -681,10 +702,12 @@ $channel = auth('doctor')->check()
             @elseif(auth('doctor')->check())
             Echo.leave('create-receipt.doctor.{{ auth('doctor')->id() }}');
             Echo.leave('confirm-appointment.doctor.{{ auth('doctor')->id() }}');
+            Echo.leave('create-diagnosis.doctor.{{ auth('doctor')->id() }}');
             @elseif(auth('patient')->check())
             Echo.leave('create-receipt.patient.{{ auth('patient')->id() }}');
             Echo.leave('create-payment.patient.{{ auth('patient')->id() }}');
             Echo.leave('confirm-appointment.patient.{{ auth('patient')->id() }}');
+            Echo.leave('create-diagnosis.patient.{{ auth('patient')->id() }}');
             @endif
             }
         } catch (e) {}


### PR DESCRIPTION
## Summary
- handle diagnosis created event in dashboard header
- subscribe to diagnosis notifications for doctors and patients
- clean up diagnosis channels when offline

## Testing
- `./vendor/bin/phpunit` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b60961b49483289db244f9fbceefc5