### PR TITLE
Broadcast laboratorie creation events

### DIFF
--- a/app/Events/LaboratorieCreated.php
+++ b/app/Events/LaboratorieCreated.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class LaboratorieCreated implements ShouldBroadcast
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public $message;
+    public $patient_id;
+    public $doctor_id;
+    public $created_at;
+
+    public function __construct($message, $patient_id, $doctor_id)
+    {
+        $this->message = $message;
+        $this->patient_id = $patient_id;
+        $this->doctor_id = $doctor_id;
+        $this->created_at = date('Y-m-d H:i:s');
+    }
+
+    public function broadcastOn()
+    {
+        return [
+            new PrivateChannel('create-laboratorie.laboratorie_employee'),
+            new PrivateChannel('create-laboratorie.patient.' . $this->patient_id),
+            new PrivateChannel('create-laboratorie.doctor.' . $this->doctor_id),
+        ];
+    }
+
+    public function broadcastAs()
+    {
+        return 'laboratorie-created';
+    }
+
+    public function broadcastWhen()
+    {
+        return \App\Support\Net::online();
+    }
+}

--- a/app/Repository/doctor_dashboard/LaboratoriesRepository.php
+++ b/app/Repository/doctor_dashboard/LaboratoriesRepository.php
@@ -5,6 +5,9 @@ namespace App\Repository\doctor_dashboard;
 use App\Interfaces\doctor_dashboard\LaboratoriesRepositoryInterface;
 use App\Models\Laboratorie;
 use App\Models\Invoice;
+use App\Models\LaboratorieEmployee;
+use App\Models\Notification;
+use App\Events\LaboratorieCreated;
 use Carbon\Carbon;
 
 class LaboratoriesRepository implements LaboratoriesRepositoryInterface
@@ -23,6 +26,27 @@ class LaboratoriesRepository implements LaboratoriesRepositoryInterface
             Invoice::findOrFail($request->invoice_id)->update([
                 'invoice_status' => 3,
             ]);
+            $message = 'تم إضافة طلب مختبر للمريض رقم ' . $request->patient_id;
+
+            foreach (LaboratorieEmployee::all() as $employee) {
+                Notification::create([
+                    'user_id' => $employee->id,
+                    'message' => $message,
+                ]);
+            }
+
+            Notification::create([
+                'user_id' => $request->patient_id,
+                'message' => $message,
+            ]);
+
+            Notification::create([
+                'user_id' => $request->doctor_id,
+                'message' => $message,
+            ]);
+
+            event(new LaboratorieCreated($message, $request->patient_id, $request->doctor_id));
+
             session()->flash('add');
             return redirect()->back();
         }
@@ -61,6 +85,26 @@ class LaboratoriesRepository implements LaboratoriesRepositoryInterface
             Invoice::findOrFail($request->invoice_id)->update([
                 'invoice_status' => 2 ,
             ]);
+            $message = 'تم إضافة مراجعة مختبر للمريض رقم ' . $request->patient_id;
+
+            foreach (LaboratorieEmployee::all() as $employee) {
+                Notification::create([
+                    'user_id' => $employee->id,
+                    'message' => $message,
+                ]);
+            }
+
+            Notification::create([
+                'user_id' => $request->patient_id,
+                'message' => $message,
+            ]);
+
+            Notification::create([
+                'user_id' => $request->doctor_id,
+                'message' => $message,
+            ]);
+
+            event(new LaboratorieCreated($message, $request->patient_id, $request->doctor_id));
 
             session()->flash('add');
             return redirect()->back();

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -23,6 +23,7 @@ Broadcast::channel('create-patient.admin', fn($user) => auth('admin')->check(), 
 Broadcast::channel('create-payment.admin', fn($user) => auth('admin')->check(), ['guards' => ['admin']]);
 Broadcast::channel('create-appointment.admin', fn($user) => auth('admin')->check(), ['guards' => ['admin']]);
 Broadcast::channel('create-ray.ray_employee', fn($user) => auth('ray_employee')->check(), ['guards' => ['ray_employee']]);
+Broadcast::channel('create-laboratorie.laboratorie_employee', fn($user) => auth('laboratorie_employee')->check(), ['guards' => ['laboratorie_employee']]);
 Broadcast::channel(
     'create-invoice.{doctor_id}',
     function ($user, $doctor_id) {
@@ -98,6 +99,22 @@ Broadcast::channel(
 
 Broadcast::channel(
     'create-ray.doctor.{doctor_id}',
+    function ($user, $doctor_id) {
+        return $user->id == $doctor_id;
+    },
+    ['guards' => ['web', 'admin', 'patient', 'doctor', 'ray_employee', 'laboratorie_employee', 'api']]
+);
+
+Broadcast::channel(
+    'create-laboratorie.patient.{patient_id}',
+    function ($user, $patient_id) {
+        return $user->id == $patient_id;
+    },
+    ['guards' => ['web', 'admin', 'patient', 'doctor', 'ray_employee', 'laboratorie_employee', 'api']]
+);
+
+Broadcast::channel(
+    'create-laboratorie.doctor.{doctor_id}',
     function ($user, $doctor_id) {
         return $user->id == $doctor_id;
     },


### PR DESCRIPTION
## Summary
- add LaboratorieCreated broadcast event for laboratorie requests and reviews
- register broadcasting channels for laboratorie employees, patients, and doctors
- notify stakeholders and dispatch event from LaboratoriesRepository

## Testing
- `vendor/bin/phpunit` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b60d9c3df88328ba3180245016952a