### PR TITLE
Add translations for receipt print view

### DIFF
--- a/resources/lang/ar/Dashboard/Receipt.php
+++ b/resources/lang/ar/Dashboard/Receipt.php
@@ -1,0 +1,16 @@
+<?php
+
+return [
+    'Title' => 'معاينة الطباعة',
+    'ReceiptVoucher' => 'سند قبض',
+    'BreadcrumbPrint' => 'طباعه سند',
+    'ProgramName' => 'برنامج ادراه المستشفي',
+    'UniversityName' => 'جامعة حلب الحرة',
+    'ReceiptInfo' => 'معلومات السند',
+    'IssueDate' => 'تاريخ الاصدار',
+    'PatientName' => 'اسم المريض',
+    'Notes' => 'ملاحظات',
+    'Amount' => 'المبلغ',
+    'PrintButton' => 'طباعه',
+];
+

--- a/resources/lang/en/Dashboard/Receipt.php
+++ b/resources/lang/en/Dashboard/Receipt.php
@@ -1,0 +1,16 @@
+<?php
+
+return [
+    'Title' => 'Print Preview',
+    'ReceiptVoucher' => 'Receipt Voucher',
+    'BreadcrumbPrint' => 'Print Receipt',
+    'ProgramName' => 'Hospital Management Program',
+    'UniversityName' => 'Free Aleppo University',
+    'ReceiptInfo' => 'Receipt Information',
+    'IssueDate' => 'Issue Date',
+    'PatientName' => 'Patient Name',
+    'Notes' => 'Notes',
+    'Amount' => 'Amount',
+    'PrintButton' => 'Print',
+];
+

--- a/resources/views/Dashboard/Receipt/print.blade.php
+++ b/resources/views/Dashboard/Receipt/print.blade.php
@@ -1,6 +1,6 @@
 @extends('Dashboard.layouts.master')
 @section('title')
-   معاينة الطباعة
+   {{ trans('Dashboard/Receipt.Title') }}
 @stop
 @section('css')
     <style>
@@ -16,7 +16,7 @@
     <div class="breadcrumb-header justify-content-between">
         <div class="my-auto">
             <div class="d-flex">
-                <h4 class="content-title mb-0 my-auto">سند قبض</h4><span class="text-muted mt-1 tx-13 mr-2 mb-0">/ طباعه سند</span>
+                <h4 class="content-title mb-0 my-auto">{{ trans('Dashboard/Receipt.ReceiptVoucher') }}</h4><span class="text-muted mt-1 tx-13 mr-2 mb-0">/ {{ trans('Dashboard/Receipt.BreadcrumbPrint') }}</span>
             </div>
         </div>
     </div>
@@ -30,20 +30,20 @@
                 <div class="card card-invoice">
                     <div class="card-body">
                         <div class="invoice-header">
-                            <h1 class="invoice-title">سند قبض</h1>
+                            <h1 class="invoice-title">{{ trans('Dashboard/Receipt.ReceiptVoucher') }}</h1>
                             <div class="billed-from">
-                                <h6>برنامج ادراه المستشفي </h6>
-                                <p>جامعة حلب الحرة<br>
+                                <h6>{{ trans('Dashboard/Receipt.ProgramName') }}</h6>
+                                <p>{{ trans('Dashboard/Receipt.UniversityName') }}<br>
                                     Tel No: 00905528779087<br>
                                     Email: info@moh.gov.sy</p>
                             </div><!-- billed-from -->
                         </div><!-- invoice-header -->
                         <div class="row mg-t-20">
                             <div class="col-md">
-                                <label class="tx-gray-600">معلومات السند</label>
-                                <p class="invoice-info-row"><span>تاريخ الاصدار</span> <span>{{$receipt->date}}</span>
+                                <label class="tx-gray-600">{{ trans('Dashboard/Receipt.ReceiptInfo') }}</label>
+                                <p class="invoice-info-row"><span>{{ trans('Dashboard/Receipt.IssueDate') }}</span> <span>{{$receipt->date}}</span>
                                 </p>
-                                <p class="invoice-info-row "><span>اسم المريض</span>
+                                <p class="invoice-info-row "><span>{{ trans('Dashboard/Receipt.PatientName') }}</span>
                                     <span>{{$receipt->patients->name}}</span></p>
                             </div>
                         </div>
@@ -52,8 +52,8 @@
                                 <thead>
                                 <tr>
                                     <th class="wd-20p">#</th>
-                                    <th class="wd-40p">ملاحظات</th>
-                                    <th class="tx-center">المبلغ</th>
+                                    <th class="wd-40p">{{ trans('Dashboard/Receipt.Notes') }}</th>
+                                    <th class="tx-center">{{ trans('Dashboard/Receipt.Amount') }}</th>
                                 </tr>
                                 </thead>
                                 <tbody>
@@ -67,7 +67,7 @@
                         </div>
                         <hr class="mg-b-40">
                         <a href="#" class="btn btn-danger float-left mt-3 mr-2" id="print_Button" onclick="printDiv()">
-                            <i class="mdi mdi-printer ml-1"></i>طباعه
+                            <i class="mdi mdi-printer ml-1"></i>{{ trans('Dashboard/Receipt.PrintButton') }}
                         </a>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- add Arabic and English translation files for receipt printing
- use translation keys in receipt print view instead of hardcoded text

## Testing
- `vendor/bin/phpunit` *(fails: Expected response status code [200] but received 302. Tests: 17, Assertions: 2, Errors: 15, Failures: 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b6116ac4848328abc2948e61d0d610