### PR TITLE
Broadcast ray diagnosis creation

### DIFF
--- a/app/Events/RayDiagnosisCreated.php
+++ b/app/Events/RayDiagnosisCreated.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class RayDiagnosisCreated implements ShouldBroadcast
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public $message;
+    public $patient_id;
+    public $doctor_id;
+    public $created_at;
+
+    public function __construct($message, $patient_id, $doctor_id)
+    {
+        $this->message = $message;
+        $this->patient_id = $patient_id;
+        $this->doctor_id = $doctor_id;
+        $this->created_at = date('Y-m-d H:i:s');
+    }
+
+    public function broadcastOn()
+    {
+        return [
+            new PrivateChannel('create-ray-diagnosis.ray_employee'),
+            new PrivateChannel('create-ray-diagnosis.patient.' . $this->patient_id),
+            new PrivateChannel('create-ray-diagnosis.doctor.' . $this->doctor_id),
+        ];
+    }
+
+    public function broadcastAs()
+    {
+        return 'ray-diagnosis-created';
+    }
+
+    public function broadcastWhen()
+    {
+        return \App\Support\Net::online();
+    }
+}

--- a/app/Repository/Dashboard_Ray_Employee/InvoicesRepository.php
+++ b/app/Repository/Dashboard_Ray_Employee/InvoicesRepository.php
@@ -4,6 +4,9 @@ namespace App\Repository\Dashboard_Ray_Employee;
 
 use App\Interfaces\Dashboard_Ray_Employee\InvoicesRepositoryInterface;
 use App\Models\Ray;
+use App\Models\RayEmployee;
+use App\Models\Notification;
+use App\Events\RayDiagnosisCreated;
 use App\Traits\UploadTrait;
 use Illuminate\Support\Facades\DB;
 
@@ -48,6 +51,28 @@ class InvoicesRepository implements InvoicesRepositoryInterface
          }
 
        }
+
+       $message = 'تم إضافة تشخيص أشعة للمريض رقم ' . $invoice->patient_id;
+
+       foreach (RayEmployee::all() as $employee) {
+           Notification::create([
+               'user_id' => $employee->id,
+               'message' => $message,
+           ]);
+       }
+
+       Notification::create([
+           'user_id' => $invoice->patient_id,
+           'message' => $message,
+       ]);
+
+       Notification::create([
+           'user_id' => $invoice->doctor_id,
+           'message' => $message,
+       ]);
+
+       event(new RayDiagnosisCreated($message, $invoice->patient_id, $invoice->doctor_id));
+
        session()->flash('edit');
        return redirect()->route('invoices_ray_employee.index');
 

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -23,6 +23,7 @@ Broadcast::channel('create-patient.admin', fn($user) => auth('admin')->check(), 
 Broadcast::channel('create-payment.admin', fn($user) => auth('admin')->check(), ['guards' => ['admin']]);
 Broadcast::channel('create-appointment.admin', fn($user) => auth('admin')->check(), ['guards' => ['admin']]);
 Broadcast::channel('create-ray.ray_employee', fn($user) => auth('ray_employee')->check(), ['guards' => ['ray_employee']]);
+Broadcast::channel('create-ray-diagnosis.ray_employee', fn($user) => auth('ray_employee')->check(), ['guards' => ['ray_employee']]);
 Broadcast::channel('create-laboratorie.laboratorie_employee', fn($user) => auth('laboratorie_employee')->check(), ['guards' => ['laboratorie_employee']]);
 Broadcast::channel(
     'create-invoice.{doctor_id}',
@@ -99,6 +100,22 @@ Broadcast::channel(
 
 Broadcast::channel(
     'create-ray.doctor.{doctor_id}',
+    function ($user, $doctor_id) {
+        return $user->id == $doctor_id;
+    },
+    ['guards' => ['web', 'admin', 'patient', 'doctor', 'ray_employee', 'laboratorie_employee', 'api']]
+);
+
+Broadcast::channel(
+    'create-ray-diagnosis.patient.{patient_id}',
+    function ($user, $patient_id) {
+        return $user->id == $patient_id;
+    },
+    ['guards' => ['web', 'admin', 'patient', 'doctor', 'ray_employee', 'laboratorie_employee', 'api']]
+);
+
+Broadcast::channel(
+    'create-ray-diagnosis.doctor.{doctor_id}',
     function ($user, $doctor_id) {
         return $user->id == $doctor_id;
     },


### PR DESCRIPTION
## Summary
- broadcast ray-diagnosis-created event to ray employee, patient, and doctor channels
- register create-ray-diagnosis broadcast channels
- notify relevant users when ray diagnosis is saved and fire event

## Testing
- `vendor/bin/phpunit --stop-on-failure 2>&1 | head -n 40` (fails: SQLSTATE[HY000] [2002] Connection refused)


------
https://chatgpt.com/codex/tasks/task_e_68b611e62ca883288906263ef1409f5d