### PR TITLE
Localize single invoice print view

### DIFF
--- a/resources/lang/ar/invoices.php
+++ b/resources/lang/ar/invoices.php
@@ -4,6 +4,7 @@ return array (
     'PrintInvoices' => 'طباعه الفواتير',
     'Invoices' => 'الفواتير',
     'GroupInvoiceTitle' => 'فاتوره مجموعة خدمات',
+    'SingleServiceInvoice' => 'فاتوره خدمه مفرده',
     'InvoiceInfo' => 'معلومات الفاتوره',
     'InvoiceDate' => 'تاريخ الفاتوره',
     'Doctor' => 'الدكتور',
@@ -20,5 +21,7 @@ return array (
     'Patient_Share' => 'حصة المريض',
     'Insurance_Discount' => 'خصم التأمين',
     'Company_Rate' => 'نسبة الشركة',
+    'Cash' => 'نقدي',
+    'Credit' => 'اجل',
     'PrintButton' => 'طباعه',
 );

--- a/resources/lang/en/invoices.php
+++ b/resources/lang/en/invoices.php
@@ -4,6 +4,7 @@ return array (
     'PrintInvoices' => 'Print Invoices',
     'Invoices' => 'Invoices',
     'GroupInvoiceTitle' => 'Group Services Invoice',
+    'SingleServiceInvoice' => 'Single Service Invoice',
     'InvoiceInfo' => 'Invoice Info',
     'InvoiceDate' => 'Invoice Date',
     'Doctor' => 'Doctor',
@@ -20,5 +21,7 @@ return array (
     'Patient_Share' => 'Patient Share',
     'Insurance_Discount' => 'Insurance Discount',
     'Company_Rate' => 'Company Rate',
+    'Cash' => 'Cash',
+    'Credit' => 'Credit',
     'PrintButton' => 'Print',
 );

--- a/resources/views/livewire/single_invoices/print.blade.php
+++ b/resources/views/livewire/single_invoices/print.blade.php
@@ -1,6 +1,6 @@
 @extends('Dashboard.layouts.master')
 @section('title')
-    طباعه الفواتير
+    {{ trans('invoices.PrintInvoices') }}
 @stop
 @section('css')
     <style>
@@ -16,7 +16,7 @@
     <div class="breadcrumb-header justify-content-between">
         <div class="my-auto">
             <div class="d-flex">
-                <h4 class="content-title mb-0 my-auto">الفواتير</h4><span class="text-muted mt-1 tx-13 mr-2 mb-0">/ طباعه الفواتير</span>
+                <h4 class="content-title mb-0 my-auto">{{ trans('invoices.Invoices') }}</h4><span class="text-muted mt-1 tx-13 mr-2 mb-0">/ {{ trans('invoices.PrintInvoices') }}</span>
             </div>
         </div>
     </div>
@@ -30,9 +30,9 @@
                 <div class="card card-invoice">
                     <div class="card-body">
                         <div class="invoice-header">
-                            <h1 class="invoice-title">فاتوره خدمه مفرده</h1>
+                            <h1 class="invoice-title">{{ trans('invoices.SingleServiceInvoice') }}</h1>
                             <div class="billed-from">
-                                <h6>فاتوره خدمه مفرده</h6>
+                                <h6>{{ trans('invoices.SingleServiceInvoice') }}</h6>
                                 <p>جامعة حلب الحرة<br>
                                     Tel No: 00905528779087<br>
                                     Email: info@moh.gov.sy</p>
@@ -41,12 +41,12 @@
                         <div class="row mg-t-20">
 
                             <div class="col-md">
-                                <label class="tx-gray-600">معلومات الفاتوره</label>
+                                <label class="tx-gray-600">{{ trans('invoices.InvoiceInfo') }}</label>
                                 {{--                                <p class="invoice-info-row"><span>اسم الخدمه</span> <span>{{$single_invoice->Service->name}}</span></p>--}}
                                 {{--                                <p class="invoice-info-row"><span>اسم المريض</span> <span>{{$single_invoice->patient->name}}</span></p>--}}
-                                <p class="invoice-info-row"><span>تاريخ الفاتوره</span> <span>{{ Request::get('invoice_date') }}</span></p>
-                                <p class="invoice-info-row"><span>الدكتور</span> <span></span>{{ Request::get('doctor_id') }}</p>
-                                <p class="invoice-info-row"><span>القسم</span> <span></span>{{ Request::get('section_id') }}</p>
+                                <p class="invoice-info-row"><span>{{ trans('invoices.InvoiceDate') }}</span> <span>{{ Request::get('invoice_date') }}</span></p>
+                                <p class="invoice-info-row"><span>{{ trans('invoices.Doctor') }}</span> <span></span>{{ Request::get('doctor_id') }}</p>
+                                <p class="invoice-info-row"><span>{{ trans('invoices.Section') }}</span> <span></span>{{ Request::get('section_id') }}</p>
                             </div>
                         </div>
                         <div class="table-responsive mg-t-40">
@@ -54,9 +54,9 @@
                                 <thead>
                                 <tr>
                                     <th class="wd-20p">#</th>
-                                    <th class="wd-40p">اسم الخدمه</th>
-                                    <th class="tx-center">سعر الخدمه</th>
-                                    <th class="tx-right">نوع الفاتوره</th>
+                                    <th class="wd-40p">{{ trans('invoices.ServiceName') }}</th>
+                                    <th class="tx-center">{{ trans('invoices.ServicePrice') }}</th>
+                                    <th class="tx-right">{{ trans('invoices.InvoiceType') }}</th>
                                 </tr>
                                 </thead>
                                 <tbody>
@@ -64,7 +64,7 @@
                                     <td>1</td>
                                     <td class="tx-12">{{ Request::get('Service_id') }}</td>
                                     <td class="tx-center">{{ Request::get('price') }}</td>
-                                    <td class="tx-right">{{Request::get('type') == 1 ? 'نقدي' : 'اجل'}}</td>
+                                    <td class="tx-right">{{ Request::get('type') == 1 ? trans('invoices.Cash') : trans('invoices.Credit') }}</td>
                                 </tr>
                                 <tr>
                                     <td class="valign-middle" colspan="2" rowspan="4">
@@ -72,19 +72,19 @@
                                             <label class="main-content-label tx-13"></label>
                                         </div><!-- invoice-notes -->
                                     </td>
-                                    <td class="tx-right">الاجمالي</td>
+                                    <td class="tx-right">{{ trans('invoices.Total') }}</td>
                                     <td class="tx-right" colspan="2"> {{number_format(Request::get('price'), 2)}}</td>
                                 </tr>
                                 <tr>
-                                    <td class="tx-right">قيمة الخصم</td>
+                                    <td class="tx-right">{{ trans('invoices.DiscountValue') }}</td>
                                     <td class="tx-right" colspan="2">{{Request::get('discount_value')}}</td>
                                 </tr>
                                 <tr>
-                                    <td class="tx-right">نسبة الضريبة</td>
+                                    <td class="tx-right">{{ trans('invoices.TaxRate') }}</td>
                                     <td class="tx-right" colspan="2">% {{Request::get('tax_rate')}}</td>
                                 </tr>
                                 <tr>
-                                    <td class="tx-right tx-uppercase tx-bold tx-inverse">الاجمالي شامل الضريبه</td>
+                                    <td class="tx-right tx-uppercase tx-bold tx-inverse">{{ trans('invoices.TotalWithTax') }}</td>
                                     <td class="tx-right" colspan="2">
                                         <h4 class="tx-primary tx-bold">{{number_format(Request::get('total_with_tax'), 2)}}</h4>
 
@@ -117,7 +117,7 @@
                         </div>
                         <hr class="mg-b-40">
                         <a href="#" class="btn btn-danger float-left mt-3 mr-2" id="print_Button" onclick="printDiv()">
-                            <i class="mdi mdi-printer ml-1"></i>طباعه
+                            <i class="mdi mdi-printer ml-1"></i>{{ trans('invoices.PrintButton') }}
                         </a>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- Localize all text in the single invoice print view using translation keys
- Add SingleServiceInvoice, Cash, and Credit strings to invoices language files

## Testing
- `php artisan test` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b6131926d0832880ba526b24d54ed7