### PR TITLE
Add laboratorie diagnosis broadcast event

### DIFF
--- a/app/Events/LaboratorieDiagnosisCreated.php
+++ b/app/Events/LaboratorieDiagnosisCreated.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class LaboratorieDiagnosisCreated implements ShouldBroadcast
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public $message;
+    public $patient_id;
+    public $doctor_id;
+    public $created_at;
+
+    public function __construct($message, $patient_id, $doctor_id)
+    {
+        $this->message = $message;
+        $this->patient_id = $patient_id;
+        $this->doctor_id = $doctor_id;
+        $this->created_at = date('Y-m-d H:i:s');
+    }
+
+    public function broadcastOn()
+    {
+        return [
+            new PrivateChannel('create-laboratorie-diagnosis.laboratorie_employee'),
+            new PrivateChannel('create-laboratorie-diagnosis.patient.' . $this->patient_id),
+            new PrivateChannel('create-laboratorie-diagnosis.doctor.' . $this->doctor_id),
+        ];
+    }
+
+    public function broadcastAs()
+    {
+        return 'laboratorie-diagnosis-created';
+    }
+
+    public function broadcastWhen()
+    {
+        return \App\Support\Net::online();
+    }
+}

--- a/app/Repository/Dashboard_Laboratorie_Employee/InvoicesRepository.php
+++ b/app/Repository/Dashboard_Laboratorie_Employee/InvoicesRepository.php
@@ -3,10 +3,11 @@
 namespace App\Repository\Dashboard_Laboratorie_Employee;
 
 use App\Interfaces\Dashboard_Laboratorie_Employee\InvoicesRepositoryInterface;
-use App\Models\Diagnostic;
 use App\Models\Laboratorie;
 use App\Models\Patient;
-use App\Models\Ray;
+use App\Models\LaboratorieEmployee;
+use App\Models\Notification;
+use App\Events\LaboratorieDiagnosisCreated;
 use App\Traits\UploadTrait;
 
 class InvoicesRepository implements InvoicesRepositoryInterface
@@ -49,6 +50,27 @@ class InvoicesRepository implements InvoicesRepositoryInterface
                 $this->verifyAndStoreImageForeach($photo,'laboratories','upload_image',$invoice->id,'App\Models\Laboratorie');
             }
         }
+        $message = 'تم إضافة تشخيص تحليل للمريض رقم ' . $invoice->patient_id;
+
+        foreach (LaboratorieEmployee::all() as $employee) {
+            Notification::create([
+                'user_id' => $employee->id,
+                'message' => $message,
+            ]);
+        }
+
+        Notification::create([
+            'user_id' => $invoice->patient_id,
+            'message' => $message,
+        ]);
+
+        Notification::create([
+            'user_id' => $invoice->doctor_id,
+            'message' => $message,
+        ]);
+
+        event(new LaboratorieDiagnosisCreated($message, $invoice->patient_id, $invoice->doctor_id));
+
         session()->flash('edit');
         return redirect()->route('invoices_ray_employee.index');
 

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -25,6 +25,7 @@ Broadcast::channel('create-appointment.admin', fn($user) => auth('admin')->check
 Broadcast::channel('create-ray.ray_employee', fn($user) => auth('ray_employee')->check(), ['guards' => ['ray_employee']]);
 Broadcast::channel('create-ray-diagnosis.ray_employee', fn($user) => auth('ray_employee')->check(), ['guards' => ['ray_employee']]);
 Broadcast::channel('create-laboratorie.laboratorie_employee', fn($user) => auth('laboratorie_employee')->check(), ['guards' => ['laboratorie_employee']]);
+Broadcast::channel('create-laboratorie-diagnosis.laboratorie_employee', fn($user) => auth('laboratorie_employee')->check(), ['guards' => ['laboratorie_employee']]);
 Broadcast::channel(
     'create-invoice.{doctor_id}',
     function ($user, $doctor_id) {
@@ -132,6 +133,22 @@ Broadcast::channel(
 
 Broadcast::channel(
     'create-laboratorie.doctor.{doctor_id}',
+    function ($user, $doctor_id) {
+        return $user->id == $doctor_id;
+    },
+    ['guards' => ['web', 'admin', 'patient', 'doctor', 'ray_employee', 'laboratorie_employee', 'api']]
+);
+
+Broadcast::channel(
+    'create-laboratorie-diagnosis.patient.{patient_id}',
+    function ($user, $patient_id) {
+        return $user->id == $patient_id;
+    },
+    ['guards' => ['web', 'admin', 'patient', 'doctor', 'ray_employee', 'laboratorie_employee', 'api']]
+);
+
+Broadcast::channel(
+    'create-laboratorie-diagnosis.doctor.{doctor_id}',
     function ($user, $doctor_id) {
         return $user->id == $doctor_id;
     },


### PR DESCRIPTION
## Summary
- add `LaboratorieDiagnosisCreated` event broadcasting to laboratorie employees, patient, and doctor channels
- register laboratorie diagnosis broadcast channels
- notify lab staff, patient, and doctor when a laboratorie diagnosis is added

## Testing
- `./vendor/bin/phpunit` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b6134af9ec8328b04ccf29b8fb6888