### PR TITLE
feat: add RayEmployee translations

### DIFF
--- a/resources/lang/ar/Dashboard/RayEmployee.php
+++ b/resources/lang/ar/Dashboard/RayEmployee.php
@@ -1,0 +1,31 @@
+<?php
+
+return [
+    'DashboardTitle' => 'لوحة تحكم موظفي الاشعة',
+    'WelcomeBack' => 'مرحبا بعودتك مرة اخري',
+    'TotalInvoices' => 'اجمالي عدد الفواتير',
+    'PendingInvoices' => 'اجمالي عدد الفواتير تحت الاجراء',
+    'CompletedInvoices' => 'اجمالي عدد الفواتير المكتملة',
+    'LatestInvoices' => 'اخر 5 فواتير علي النظام',
+    'Reports' => 'الكشوفات',
+    'Invoices' => 'الفواتير',
+    'InvoiceDate' => 'تاريخ الفاتورة',
+    'PatientName' => 'اسم المريض',
+    'DoctorName' => 'اسم الدكتور',
+    'Description' => 'المطلوب',
+    'InvoiceStatus' => 'حالة الفاتورة',
+    'Operations' => 'العمليات',
+    'AddDiagnosis' => 'اضافة تشخيص',
+    'UnderProcessing' => 'تحت الاجراء',
+    'Completed' => 'مكتملة',
+    'NoData' => 'لاتوجد بيانات',
+    'Diagnosis' => 'التشخيص',
+    'Attachments' => 'المرفقات',
+    'Confirm' => 'تاكيد',
+    'DoctorDetails' => 'تفاصيل الدكتور',
+    'PatientDetails' => 'تفاصيل المريض',
+    'XRayImages' => 'صور الاشعة',
+    'ViewImages' => 'عرض الصور',
+    'RadiologistNotes' => 'ملاحظات دكتور الاشعة',
+];
+

--- a/resources/lang/en/Dashboard/RayEmployee.php
+++ b/resources/lang/en/Dashboard/RayEmployee.php
@@ -1,0 +1,31 @@
+<?php
+
+return [
+    'DashboardTitle' => 'Ray Employee Dashboard',
+    'WelcomeBack' => 'Welcome back',
+    'TotalInvoices' => 'Total Invoices',
+    'PendingInvoices' => 'Total Pending Invoices',
+    'CompletedInvoices' => 'Total Completed Invoices',
+    'LatestInvoices' => 'Latest 5 invoices on the system',
+    'Reports' => 'Reports',
+    'Invoices' => 'Invoices',
+    'InvoiceDate' => 'Invoice Date',
+    'PatientName' => 'Patient Name',
+    'DoctorName' => 'Doctor Name',
+    'Description' => 'Description',
+    'InvoiceStatus' => 'Invoice Status',
+    'Operations' => 'Operations',
+    'AddDiagnosis' => 'Add Diagnosis',
+    'UnderProcessing' => 'Under Processing',
+    'Completed' => 'Completed',
+    'NoData' => 'No data available',
+    'Diagnosis' => 'Diagnosis',
+    'Attachments' => 'Attachments',
+    'Confirm' => 'Confirm',
+    'DoctorDetails' => 'Doctor Details',
+    'PatientDetails' => 'Patient Details',
+    'XRayImages' => 'X-ray Images',
+    'ViewImages' => 'View Images',
+    'RadiologistNotes' => 'Radiologist Notes',
+];
+

--- a/resources/views/Dashboard/dashboard_RayEmployee/dashboard.blade.php
+++ b/resources/views/Dashboard/dashboard_RayEmployee/dashboard.blade.php
@@ -10,8 +10,8 @@
 <div class="breadcrumb-header justify-content-between">
 	<div class="left-content">
 		<div>
-			<h2 class="main-content-title tx-24 mg-b-1 mg-b-lg-1">لوحة تحكم موظفي الاشعة</h2><br>
-			<p class="mg-b-0">مرحبا بعودتك مرة اخري {{auth()->user()->name}}</p>
+                        <h2 class="main-content-title tx-24 mg-b-1 mg-b-lg-1">{{ trans('Dashboard/RayEmployee.DashboardTitle') }}</h2><br>
+                        <p class="mg-b-0">{{ trans('Dashboard/RayEmployee.WelcomeBack') }} {{auth()->user()->name}}</p>
 		</div>
 	</div>
 </div>
@@ -24,7 +24,7 @@
 		<div class="card overflow-hidden sales-card bg-primary-gradient">
 			<div class="pl-3 pt-3 pr-3 pb-2 pt-0">
 				<div class="">
-					<h6 class="mb-3 tx-12 text-white">اجمالي عدد الفواتير</h6>
+                                        <h6 class="mb-3 tx-12 text-white">{{ trans('Dashboard/RayEmployee.TotalInvoices') }}</h6>
 				</div>
 				<div class="pb-0 mt-0">
 					<div class="d-flex">
@@ -41,7 +41,7 @@
 		<div class="card overflow-hidden sales-card bg-danger-gradient">
 			<div class="pl-3 pt-3 pr-3 pb-2 pt-0">
 				<div class="">
-					<h6 class="mb-3 tx-12 text-white">اجمالي عدد الفواتير تحت الاجراء</h6>
+                                        <h6 class="mb-3 tx-12 text-white">{{ trans('Dashboard/RayEmployee.PendingInvoices') }}</h6>
 				</div>
 				<div class="pb-0 mt-0">
 					<div class="d-flex">
@@ -58,7 +58,7 @@
 		<div class="card overflow-hidden sales-card bg-success-gradient">
 			<div class="pl-3 pt-3 pr-3 pb-2 pt-0">
 				<div class="">
-					<h6 class="mb-3 tx-12 text-white">اجمالي عدد الفواتير المكتملة</h6>
+                                        <h6 class="mb-3 tx-12 text-white">{{ trans('Dashboard/RayEmployee.CompletedInvoices') }}</h6>
 				</div>
 				<div class="pb-0 mt-0">
 					<div class="d-flex">
@@ -79,18 +79,18 @@
 	<div class="col-md-12 col-lg-12 col-xl-12">
 		<div class="card card-table-two">
 			<div class="d-flex justify-content-between">
-				<h2 class="card-title mb-1">اخر 5 فواتير علي النظام</h2>
+                                <h2 class="card-title mb-1">{{ trans('Dashboard/RayEmployee.LatestInvoices') }}</h2>
 			</div><br>
 			<div class="table-responsive country-table">
 				<table class="table table-striped table-bordered mb-0 text-sm-nowrap text-lg-nowrap text-xl-nowrap">
 					<thead>
 						<tr>
 							<th>#</th>
-							<th>تاريخ الفاتورة</th>
-							<th>اسم المريض</th>
-							<th>اسم الطبيب</th>
-							<th>المطلوب</th>
-							<th>حالة الفاتورة</th>
+                                                        <th>{{ trans('Dashboard/RayEmployee.InvoiceDate') }}</th>
+                                                        <th>{{ trans('Dashboard/RayEmployee.PatientName') }}</th>
+                                                        <th>{{ trans('Dashboard/RayEmployee.DoctorName') }}</th>
+                                                        <th>{{ trans('Dashboard/RayEmployee.Description') }}</th>
+                                                        <th>{{ trans('Dashboard/RayEmployee.InvoiceStatus') }}</th>
 						</tr>
 					</thead>
 					<tbody>
@@ -111,14 +111,14 @@
 							<td class="tx-right tx-medium tx-danger">{{$invoice->description}}</td>
 							<td class="tx-right tx-medium tx-inverse">
 								@if($invoice->case == 0)
-								<span class="badge badge-danger">تحت الاجراء</span>
+                                                                <span class="badge badge-danger">{{ trans('Dashboard/RayEmployee.UnderProcessing') }}</span>
 								@else
-								<span class="badge badge-success">مكتملة</span>
+                                                                <span class="badge badge-success">{{ trans('Dashboard/RayEmployee.Completed') }}</span>
 								@endif
 							</td>
 						</tr>
 						@empty
-						لاتوجد بيانات
+                                                {{ trans('Dashboard/RayEmployee.NoData') }}
 						@endforelse
 					</tbody>
 				</table>

--- a/resources/views/Dashboard/dashboard_RayEmployee/invoices/add_diagnosis.blade.php
+++ b/resources/views/Dashboard/dashboard_RayEmployee/invoices/add_diagnosis.blade.php
@@ -1,6 +1,6 @@
 @extends('Dashboard.layouts.master')
 @section('title')
-    اضافة تشخيص
+    {{ trans('Dashboard/RayEmployee.AddDiagnosis') }}
 @stop
 @section('css')
 
@@ -10,7 +10,7 @@
     <div class="breadcrumb-header justify-content-between">
         <div class="my-auto">
             <div class="d-flex">
-                <h4 class="content-title mb-0 my-auto">اضافة تشخيص</h4><span class="text-muted mt-1 tx-13 mr-2 mb-0">/ {{ $invoice->Patient->name }}</span>
+                <h4 class="content-title mb-0 my-auto">{{ trans('Dashboard/RayEmployee.AddDiagnosis') }}</h4><span class="text-muted mt-1 tx-13 mr-2 mb-0">/ {{ $invoice->Patient->name }}</span>
             </div>
         </div>
     </div>
@@ -26,14 +26,14 @@
                         @csrf
                         @method('PUT')
                         <div class="form-group">
-                            <label for="exampleFormControlTextarea1">التشخيص</label>
+                            <label for="exampleFormControlTextarea1">{{ trans('Dashboard/RayEmployee.Diagnosis') }}</label>
                             <textarea class="form-control" id="exampleFormControlTextarea1" name="description_employee" rows="3"></textarea>
                         </div>
                         <div class="form-group">
-                            <label for="exampleFormControlTextarea1">المرفقات</label>
+                            <label for="exampleFormControlTextarea1">{{ trans('Dashboard/RayEmployee.Attachments') }}</label>
                             <input type="file" name="photos[]" accept="image/*" multiple>
                         </div>
-                        <button type="submit" class="btn btn-primary">تاكيد</button>
+                        <button type="submit" class="btn btn-primary">{{ trans('Dashboard/RayEmployee.Confirm') }}</button>
                     </form>
                 </div>
             </div>

--- a/resources/views/Dashboard/dashboard_RayEmployee/invoices/completed_invoices.blade.php
+++ b/resources/views/Dashboard/dashboard_RayEmployee/invoices/completed_invoices.blade.php
@@ -1,6 +1,6 @@
 @extends('Dashboard.layouts.master')
 @section('title')
-الفواتير المكتملة
+{{ trans('Dashboard/RayEmployee.CompletedInvoices') }}
 @stop
 @section('css')
 
@@ -12,7 +12,7 @@
 <div class="breadcrumb-header justify-content-between">
     <div class="my-auto">
         <div class="d-flex">
-            <h4 class="content-title mb-0 my-auto">الفواتير المكتملة</h4><span class="text-muted mt-1 tx-13 mr-2 mb-0">/ الفواتير</span>
+            <h4 class="content-title mb-0 my-auto">{{ trans('Dashboard/RayEmployee.CompletedInvoices') }}</h4><span class="text-muted mt-1 tx-13 mr-2 mb-0">/ {{ trans('Dashboard/RayEmployee.Invoices') }}</span>
         </div>
     </div>
 </div>
@@ -31,11 +31,11 @@
                         <thead>
                             <tr>
                                 <th>#</th>
-                                <th>{{ trans('Dashboard/RaysInvoices.InvoiceDate') }}</th>
-                                <th>{{ trans('Dashboard/RaysInvoices.PatientName') }}</th>
-                                <th>{{ trans('Dashboard/RaysInvoices.DoctorName') }}</th>
-                                <th>{{ trans('Dashboard/RaysInvoices.Description') }}</th>
-                                <th>{{ trans('Dashboard/RaysInvoices.InvoiceStatus') }}</th>
+                                <th>{{ trans('Dashboard/RayEmployee.InvoiceDate') }}</th>
+                                <th>{{ trans('Dashboard/RayEmployee.PatientName') }}</th>
+                                <th>{{ trans('Dashboard/RayEmployee.DoctorName') }}</th>
+                                <th>{{ trans('Dashboard/RayEmployee.Description') }}</th>
+                                <th>{{ trans('Dashboard/RayEmployee.InvoiceStatus') }}</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -56,9 +56,9 @@
                                 <td>{{ $invoice->description }}</td>
                                 <td>
                                     @if($invoice->case == 0)
-                                    <span class="badge badge-danger">تحت الاجراء</span>
+                                    <span class="badge badge-danger">{{ trans('Dashboard/RayEmployee.UnderProcessing') }}</span>
                                     @else
-                                    <span class="badge badge-success">مكتملة</span>
+                                    <span class="badge badge-success">{{ trans('Dashboard/RayEmployee.Completed') }}</span>
                                     @endif
                                 </td>
 

--- a/resources/views/Dashboard/dashboard_RayEmployee/invoices/doctor_details_list.blade.php
+++ b/resources/views/Dashboard/dashboard_RayEmployee/invoices/doctor_details_list.blade.php
@@ -1,6 +1,6 @@
 @extends('Dashboard.layouts.master')
 @section('title')
-    تفاصيل الدكتور
+    {{ trans('Dashboard/RayEmployee.DoctorDetails') }}
 @stop
 @section('css')
 @endsection
@@ -9,7 +9,7 @@
     <div class="breadcrumb-header justify-content-between">
         <div class="my-auto">
             <div class="d-flex">
-                <h4 class="content-title mb-0 my-auto">تفاصيل الدكتور</h4><span class="text-muted mt-1 tx-13 mr-2 mb-0">/ صور الاشعة</span>
+                <h4 class="content-title mb-0 my-auto">{{ trans('Dashboard/RayEmployee.DoctorDetails') }}</h4><span class="text-muted mt-1 tx-13 mr-2 mb-0">/ {{ trans('Dashboard/RayEmployee.XRayImages') }}</span>
             </div>
         </div>
     </div>
@@ -26,12 +26,12 @@
                             <thead>
                             <tr>
                                 <th>#</th>
-                                <th>تاريخ الفاتورة</th>
-                                <th>اسم المريض</th>
-                                <th>اسم الدكتور</th>
-                                <th>المطلوب</th>
-                                <th>حالة الفاتورة</th>
-                                <th>العمليات</th>
+                                <th>{{ trans('Dashboard/RayEmployee.InvoiceDate') }}</th>
+                                <th>{{ trans('Dashboard/RayEmployee.PatientName') }}</th>
+                                <th>{{ trans('Dashboard/RayEmployee.DoctorName') }}</th>
+                                <th>{{ trans('Dashboard/RayEmployee.Description') }}</th>
+                                <th>{{ trans('Dashboard/RayEmployee.InvoiceStatus') }}</th>
+                                <th>{{ trans('Dashboard/RayEmployee.Operations') }}</th>
                             </tr>
                             </thead>
                             <tbody>
@@ -44,13 +44,13 @@
                                     <td>{{ $ray->description }}</td>
                                     <td>
                                         @if($ray->case == 0)
-                                            <span class="badge badge-danger">تحت الاجراء</span>
+                                            <span class="badge badge-danger">{{ trans('Dashboard/RayEmployee.UnderProcessing') }}</span>
                                         @else
-                                            <span class="badge badge-success">مكتملة</span>
+                                            <span class="badge badge-success">{{ trans('Dashboard/RayEmployee.Completed') }}</span>
                                         @endif
                                     </td>
                                     <td>
-                                        <a href="{{ route('ray_view_rays', $ray->id) }}" class="btn btn-sm btn-primary">عرض الصور</a>
+                                        <a href="{{ route('ray_view_rays', $ray->id) }}" class="btn btn-sm btn-primary">{{ trans('Dashboard/RayEmployee.ViewImages') }}</a>
                                     </td>
                                 </tr>
                             @endforeach

--- a/resources/views/Dashboard/dashboard_RayEmployee/invoices/index.blade.php
+++ b/resources/views/Dashboard/dashboard_RayEmployee/invoices/index.blade.php
@@ -1,6 +1,6 @@
 @extends('Dashboard.layouts.master')
 @section('title')
-{{ trans('Dashboard/RaysInvoices.Reports') }}
+{{ trans('Dashboard/RayEmployee.Reports') }}
 @stop
 @section('css')
 
@@ -12,7 +12,7 @@
 <div class="breadcrumb-header justify-content-between">
     <div class="my-auto">
         <div class="d-flex">
-            <h4 class="content-title mb-0 my-auto">{{ trans('Dashboard/RaysInvoices.Reports') }}</h4><span class="text-muted mt-1 tx-13 mr-2 mb-0">/ {{ trans('Dashboard/RaysInvoices.Invoices') }}</span>
+            <h4 class="content-title mb-0 my-auto">{{ trans('Dashboard/RayEmployee.Reports') }}</h4><span class="text-muted mt-1 tx-13 mr-2 mb-0">/ {{ trans('Dashboard/RayEmployee.Invoices') }}</span>
         </div>
     </div>
 </div>
@@ -31,12 +31,12 @@
                         <thead>
                             <tr>
                                 <th>#</th>
-                                <th>{{ trans('Dashboard/RaysInvoices.InvoiceDate') }}</th>
-                                <th>{{ trans('Dashboard/RaysInvoices.PatientName') }}</th>
-                                <th>{{ trans('Dashboard/RaysInvoices.DoctorName') }}</th>
-                                <th>{{ trans('Dashboard/RaysInvoices.Description') }}</th>
-                                <th>{{ trans('Dashboard/RaysInvoices.InvoiceStatus') }}</th>
-                                <th>العمليات</th>
+                                <th>{{ trans('Dashboard/RayEmployee.InvoiceDate') }}</th>
+                                <th>{{ trans('Dashboard/RayEmployee.PatientName') }}</th>
+                                <th>{{ trans('Dashboard/RayEmployee.DoctorName') }}</th>
+                                <th>{{ trans('Dashboard/RayEmployee.Description') }}</th>
+                                <th>{{ trans('Dashboard/RayEmployee.InvoiceStatus') }}</th>
+                        <th>{{ trans('Dashboard/RayEmployee.Operations') }}</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -57,17 +57,17 @@
                                 <td>{{ $invoice->description }}</td>
                                 <td>
                                     @if($invoice->case == 0)
-                                    <span class="badge badge-danger">تحت الاجراء</span>
+                                    <span class="badge badge-danger">{{ trans('Dashboard/RayEmployee.UnderProcessing') }}</span>
                                     @else
-                                    <span class="badge badge-success">مكتملة</span>
+                                    <span class="badge badge-success">{{ trans('Dashboard/RayEmployee.Completed') }}</span>
                                     @endif
                                 </td>
 
                                 <td>
                                     <div class="dropdown">
-                                        <button aria-expanded="false" aria-haspopup="true" class="btn ripple btn-outline-primary btn-sm" data-toggle="dropdown" type="button">{{trans('doctors.Processes')}}<i class="fas fa-caret-down mr-1"></i></button>
+                                        <button aria-expanded="false" aria-haspopup="true" class="btn ripple btn-outline-primary btn-sm" data-toggle="dropdown" type="button">{{ trans('Dashboard/RayEmployee.Operations') }}<i class="fas fa-caret-down mr-1"></i></button>
                                         <div class="dropdown-menu tx-13">
-                                            <a class="dropdown-item" href="{{route('invoices_ray_employee.edit',$invoice->id)}}"><i class="text-primary fa fa-stethoscope"></i>&nbsp;&nbsp;اضافة تشخيص </a>
+                                            <a class="dropdown-item" href="{{route('invoices_ray_employee.edit',$invoice->id)}}"><i class="text-primary fa fa-stethoscope"></i>&nbsp;&nbsp;{{ trans('Dashboard/RayEmployee.AddDiagnosis') }} </a>
                                         </div>
                                     </div>
                                 </td>

--- a/resources/views/Dashboard/dashboard_RayEmployee/invoices/patient_details.blade.php
+++ b/resources/views/Dashboard/dashboard_RayEmployee/invoices/patient_details.blade.php
@@ -1,6 +1,6 @@
 @extends('Dashboard.layouts.master')
 @section('title')
-    الكشوفات
+    {{ trans('Dashboard/RayEmployee.Reports') }}
 @stop
 @section('css')
 
@@ -10,7 +10,7 @@
     <div class="breadcrumb-header justify-content-between">
         <div class="my-auto">
             <div class="d-flex">
-                <h4 class="content-title mb-0 my-auto">صور الاشعة</h4><span class="text-muted mt-1 tx-13 mr-2 mb-0">/ {{$rays->Patient->name}}</span>
+                <h4 class="content-title mb-0 my-auto">{{ trans('Dashboard/RayEmployee.XRayImages') }}</h4><span class="text-muted mt-1 tx-13 mr-2 mb-0">/ {{$rays->Patient->name}}</span>
             </div>
         </div>
     </div>
@@ -19,7 +19,7 @@
 @section('content')
 
     <div class="form-group">
-        <label for="exampleFormControlTextarea1">ملاحظات دكتور الاشعة</label>
+        <label for="exampleFormControlTextarea1">{{ trans('Dashboard/RayEmployee.RadiologistNotes') }}</label>
         <textarea readonly class="form-control" id="exampleFormControlTextarea1" rows="3">{{$rays->description_employee}}</textarea>
     </div>
 

--- a/resources/views/Dashboard/dashboard_RayEmployee/invoices/patient_details_list.blade.php
+++ b/resources/views/Dashboard/dashboard_RayEmployee/invoices/patient_details_list.blade.php
@@ -1,6 +1,6 @@
 @extends('Dashboard.layouts.master')
 @section('title')
-    تفاصيل المريض
+    {{ trans('Dashboard/RayEmployee.PatientDetails') }}
 @stop
 @section('css')
 @endsection
@@ -9,7 +9,7 @@
     <div class="breadcrumb-header justify-content-between">
         <div class="my-auto">
             <div class="d-flex">
-                <h4 class="content-title mb-0 my-auto">تفاصيل المريض</h4><span class="text-muted mt-1 tx-13 mr-2 mb-0">/ صور الاشعة</span>
+                <h4 class="content-title mb-0 my-auto">{{ trans('Dashboard/RayEmployee.PatientDetails') }}</h4><span class="text-muted mt-1 tx-13 mr-2 mb-0">/ {{ trans('Dashboard/RayEmployee.XRayImages') }}</span>
             </div>
         </div>
     </div>
@@ -26,12 +26,12 @@
                             <thead>
                             <tr>
                                 <th>#</th>
-                                <th>تاريخ الفاتورة</th>
-                                <th>اسم المريض</th>
-                                <th>اسم الدكتور</th>
-                                <th>المطلوب</th>
-                                <th>حالة الفاتورة</th>
-                                <th>العمليات</th>
+                                <th>{{ trans('Dashboard/RayEmployee.InvoiceDate') }}</th>
+                                <th>{{ trans('Dashboard/RayEmployee.PatientName') }}</th>
+                                <th>{{ trans('Dashboard/RayEmployee.DoctorName') }}</th>
+                                <th>{{ trans('Dashboard/RayEmployee.Description') }}</th>
+                                <th>{{ trans('Dashboard/RayEmployee.InvoiceStatus') }}</th>
+                                <th>{{ trans('Dashboard/RayEmployee.Operations') }}</th>
                             </tr>
                             </thead>
                             <tbody>
@@ -44,13 +44,13 @@
                                     <td>{{ $ray->description }}</td>
                                     <td>
                                         @if($ray->case == 0)
-                                            <span class="badge badge-danger">تحت الاجراء</span>
+                                            <span class="badge badge-danger">{{ trans('Dashboard/RayEmployee.UnderProcessing') }}</span>
                                         @else
-                                            <span class="badge badge-success">مكتملة</span>
+                                            <span class="badge badge-success">{{ trans('Dashboard/RayEmployee.Completed') }}</span>
                                         @endif
                                     </td>
                                     <td>
-                                        <a href="{{ route('ray_view_rays', $ray->id) }}" class="btn btn-sm btn-primary">عرض الصور</a>
+                                        <a href="{{ route('ray_view_rays', $ray->id) }}" class="btn btn-sm btn-primary">{{ trans('Dashboard/RayEmployee.ViewImages') }}</a>
                                     </td>
                                 </tr>
                             @endforeach


### PR DESCRIPTION
## Summary
- localize Ray Employee dashboard and invoice views
- add Arabic and English translation files for RayEmployee

## Testing
- `php artisan test` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b6148dcf188328a175fe0dce45ba35