### PR TITLE
Localize doctor dashboard and invoice pages

### DIFF
--- a/resources/lang/ar/Dashboard/Doctor.php
+++ b/resources/lang/ar/Dashboard/Doctor.php
@@ -1,0 +1,28 @@
+<?php
+
+return [
+    'Welcome' => 'مرحبا',
+    'TotalInvoices' => 'عدد الفواتير',
+    'UnderProcessing' => 'تحت الاجراء',
+    'Completed' => 'مكتملة',
+    'ReviewInvoices' => 'فواتير المراجعات',
+    'InvoiceDate' => 'تاريخ الفاتورة',
+    'ServiceName' => 'اسم الخدمة',
+    'PatientName' => 'اسم المريض',
+    'ServicePrice' => 'سعر الخدمة',
+    'DiscountValue' => 'قيمة الخصم',
+    'TaxRate' => 'نسبة الضريبة',
+    'TaxValue' => 'قيمة الضريبة',
+    'TotalWithTax' => 'الاجمالي مع الضريبة',
+    'InvoiceStatus' => 'حالة الفاتورة',
+    'Operations' => 'العمليات',
+    'AddDiagnosis' => 'اضافة تشخيص',
+    'AddReview' => 'اضافة مراجعة',
+    'XrayConversion' => 'تحويل الي الاشعة',
+    'LaboratoryConversion' => 'تحويل الي المختبر',
+    'Review' => 'مراجعة',
+    'ReviewDate' => 'تاريخ المراجعة',
+    'Invoices' => 'الكشوفات',
+    'CompletedInvoices' => 'الكشوفات المكتملة',
+];
+

--- a/resources/lang/en/Dashboard/Doctor.php
+++ b/resources/lang/en/Dashboard/Doctor.php
@@ -1,0 +1,28 @@
+<?php
+
+return [
+    'Welcome' => 'Welcome',
+    'TotalInvoices' => 'Total Invoices',
+    'UnderProcessing' => 'Under Processing',
+    'Completed' => 'Completed',
+    'ReviewInvoices' => 'Review Invoices',
+    'InvoiceDate' => 'Invoice Date',
+    'ServiceName' => 'Service Name',
+    'PatientName' => 'Patient Name',
+    'ServicePrice' => 'Service Price',
+    'DiscountValue' => 'Discount Value',
+    'TaxRate' => 'Tax Rate',
+    'TaxValue' => 'Tax Value',
+    'TotalWithTax' => 'Total with Tax',
+    'InvoiceStatus' => 'Invoice Status',
+    'Operations' => 'Operations',
+    'AddDiagnosis' => 'Add Diagnosis',
+    'AddReview' => 'Add Review',
+    'XrayConversion' => 'X-ray Conversion',
+    'LaboratoryConversion' => 'Laboratory Conversion',
+    'Review' => 'Review',
+    'ReviewDate' => 'Review Date',
+    'Invoices' => 'Invoices',
+    'CompletedInvoices' => 'Completed Invoices',
+];
+

--- a/resources/views/Dashboard/doctor/dashboard.blade.php
+++ b/resources/views/Dashboard/doctor/dashboard.blade.php
@@ -10,7 +10,7 @@
 				<div class="breadcrumb-header justify-content-between">
 					<div class="left-content">
 						<div>
-						  <h2 class="main-content-title tx-24 mg-b-1 mg-b-lg-1">  مرحبا  {{ Auth::user()->name }} </h2>
+                                                    <h2 class="main-content-title tx-24 mg-b-1 mg-b-lg-1">{{ trans('Dashboard/Doctor.Welcome') }} {{ Auth::user()->name }} </h2>
 						</div>
 					</div>
 				</div>
@@ -23,7 +23,7 @@
 						<div class="card overflow-hidden sales-card bg-primary-gradient">
 							<div class="pl-3 pt-3 pr-3 pb-2 pt-0">
 								<div class="">
-									<h6 class="mb-3 tx-12 text-white">عدد الفواتير</h6>
+                                                                        <h6 class="mb-3 tx-12 text-white">{{ trans('Dashboard/Doctor.TotalInvoices') }}</h6>
 								</div>
 								<div class="pb-0 mt-0">
 									<div class="d-flex">
@@ -40,7 +40,7 @@
 						<div class="card overflow-hidden sales-card bg-danger-gradient">
 							<div class="pl-3 pt-3 pr-3 pb-2 pt-0">
 								<div class="">
-									<h6 class="mb-3 tx-12 text-white">عدد الفواتير تحت الاجراء</h6>
+                                                                        <h6 class="mb-3 tx-12 text-white">{{ trans('Dashboard/Doctor.UnderProcessing') }}</h6>
 								</div>
 								<div class="pb-0 mt-0">
 									<div class="d-flex">
@@ -59,7 +59,7 @@
 						<div class="card overflow-hidden sales-card bg-success-gradient">
 							<div class="pl-3 pt-3 pr-3 pb-2 pt-0">
 								<div class="">
-									<h6 class="mb-3 tx-12 text-white">عدد الفواتير المكتملة</h6>
+                                                                        <h6 class="mb-3 tx-12 text-white">{{ trans('Dashboard/Doctor.Completed') }}</h6>
 								</div>
 								<div class="pb-0 mt-0">
 									<div class="d-flex">
@@ -78,7 +78,7 @@
 						<div class="card overflow-hidden sales-card bg-warning-gradient">
 							<div class="pl-3 pt-3 pr-3 pb-2 pt-0">
 								<div class="">
-									<h6 class="mb-3 tx-12 text-white">عدد فواتير المراجعات</h6>
+                                                                        <h6 class="mb-3 tx-12 text-white">{{ trans('Dashboard/Doctor.ReviewInvoices') }}</h6>
 								</div>
 								<div class="pb-0 mt-0">
 									<div class="d-flex">

--- a/resources/views/Dashboard/doctor/invoices/completed_invoices.blade.php
+++ b/resources/views/Dashboard/doctor/invoices/completed_invoices.blade.php
@@ -1,6 +1,6 @@
 @extends('Dashboard.layouts.master')
 @section('title')
-   الكشوفات المكتملة
+   {{ trans('Dashboard/Doctor.CompletedInvoices') }}
 @stop
 @section('css')
     <!-- Internal Data table css -->
@@ -21,7 +21,7 @@
 				<div class="breadcrumb-header justify-content-between">
 					<div class="my-auto">
 						<div class="d-flex">
-							<h4 class="content-title mb-0 my-auto">الكشوفات المكتملة</h4><span class="text-muted mt-1 tx-13 mr-2 mb-0">/ الفواتير</span>
+                                                        <h4 class="content-title mb-0 my-auto">{{ trans('Dashboard/Doctor.CompletedInvoices') }}</h4><span class="text-muted mt-1 tx-13 mr-2 mb-0">/ {{ trans('Dashboard/Doctor.Invoices') }}</span>
 						</div>
 					</div>
 				</div>
@@ -40,15 +40,15 @@
                                             <thead>
                                             <tr>
                                                 <th>#</th>
-                                                <th>تاريخ الفاتورة</th>
-                                                <th>اسم الخدمة</th>
-                                                <th>اسم المريض</th>
-                                                <th>سعر الخدمة</th>
-                                                <th>قيمة الخصم</th>
-                                                <th>نسبة الضريبة</th>
-                                                <th>قيمة الضريبة</th>
-                                                <th>الاجمالي مع الضريبة</th>
-                                                <th>حالة الفاتورة</th>
+                                                  <th>{{ trans('Dashboard/Doctor.InvoiceDate') }}</th>
+                                                  <th>{{ trans('Dashboard/Doctor.ServiceName') }}</th>
+                                                  <th>{{ trans('Dashboard/Doctor.PatientName') }}</th>
+                                                  <th>{{ trans('Dashboard/Doctor.ServicePrice') }}</th>
+                                                  <th>{{ trans('Dashboard/Doctor.DiscountValue') }}</th>
+                                                  <th>{{ trans('Dashboard/Doctor.TaxRate') }}</th>
+                                                  <th>{{ trans('Dashboard/Doctor.TaxValue') }}</th>
+                                                  <th>{{ trans('Dashboard/Doctor.TotalWithTax') }}</th>
+                                                  <th>{{ trans('Dashboard/Doctor.InvoiceStatus') }}</th>
                                             </tr>
                                             </thead>
                                             <tbody>
@@ -65,11 +65,11 @@
                                                    <td>{{ number_format($invoice->total_with_tax, 2) }}</td>
                                                    <td>
                                                       @if($invoice->invoice_status == 1)
-                                                           <span class="badge badge-danger">تحت الاجراء</span>
+                                                            <span class="badge badge-danger">{{ trans('Dashboard/Doctor.UnderProcessing') }}</span>
                                                       @elseif($invoice->invoice_status == 2)
-                                                           <span class="badge badge-warning">مراجعة</span>
+                                                            <span class="badge badge-warning">{{ trans('Dashboard/Doctor.Review') }}</span>
                                                        @else
-                                                          <span class="badge badge-success">مكتملة</span>
+                                                           <span class="badge badge-success">{{ trans('Dashboard/Doctor.Completed') }}</span>
                                                        @endif
                                                    </td>
                                                </tr>

--- a/resources/views/Dashboard/doctor/invoices/index.blade.php
+++ b/resources/views/Dashboard/doctor/invoices/index.blade.php
@@ -1,6 +1,6 @@
 @extends('Dashboard.layouts.master')
 @section('title')
-الكشوفات
+{{ trans('Dashboard/Doctor.Invoices') }}
 @stop
 @section('css')
 <!-- Internal Data table css -->
@@ -21,7 +21,7 @@
 <div class="breadcrumb-header justify-content-between">
     <div class="my-auto">
         <div class="d-flex">
-            <h4 class="content-title mb-0 my-auto">الكشوفات</h4><span class="text-muted mt-1 tx-13 mr-2 mb-0">/ الفواتير</span>
+            <h4 class="content-title mb-0 my-auto">{{ trans('Dashboard/Doctor.Invoices') }}</h4><span class="text-muted mt-1 tx-13 mr-2 mb-0">/ {{ trans('Dashboard/Doctor.Invoices') }}</span>
         </div>
     </div>
 </div>
@@ -40,16 +40,16 @@
                         <thead>
                             <tr>
                                 <th>#</th>
-                                <th>تاريخ الفاتورة</th>
-                                <th>اسم الخدمة</th>
-                                <th>اسم المريض</th>
-                                <th>سعر الخدمة</th>
-                                <th>قيمة الخصم</th>
-                                <th>نسبة الضريبة</th>
-                                <th>قيمة الضريبة</th>
-                                <th>الاجمالي مع الضريبة</th>
-                                <th>حالة الفاتورة</th>
-                                <th>العمليات</th>
+                                <th>{{ trans('Dashboard/Doctor.InvoiceDate') }}</th>
+                                <th>{{ trans('Dashboard/Doctor.ServiceName') }}</th>
+                                <th>{{ trans('Dashboard/Doctor.PatientName') }}</th>
+                                <th>{{ trans('Dashboard/Doctor.ServicePrice') }}</th>
+                                <th>{{ trans('Dashboard/Doctor.DiscountValue') }}</th>
+                                <th>{{ trans('Dashboard/Doctor.TaxRate') }}</th>
+                                <th>{{ trans('Dashboard/Doctor.TaxValue') }}</th>
+                                <th>{{ trans('Dashboard/Doctor.TotalWithTax') }}</th>
+                                <th>{{ trans('Dashboard/Doctor.InvoiceStatus') }}</th>
+                                <th>{{ trans('Dashboard/Doctor.Operations') }}</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -66,11 +66,11 @@
                                 <td>{{ number_format($invoice->total_with_tax, 2) }}</td>
                                 <td>
                                     @if($invoice->invoice_status == 1)
-                                    <span class="badge badge-danger">تحت الاجراء</span>
+                                    <span class="badge badge-danger">{{ trans('Dashboard/Doctor.UnderProcessing') }}</span>
                                     @elseif($invoice->invoice_status == 2)
-                                    <span class="badge badge-warning">مراجعة</span>
+                                    <span class="badge badge-warning">{{ trans('Dashboard/Doctor.Review') }}</span>
                                     @else
-                                    <span class="badge badge-success">مكتملة</span>
+                                    <span class="badge badge-success">{{ trans('Dashboard/Doctor.Completed') }}</span>
                                     @endif
                                 </td>
 
@@ -79,11 +79,11 @@
                                     <div class="dropdown">
                                         <button aria-expanded="false" aria-haspopup="true" class="btn ripple btn-outline-primary btn-sm" data-toggle="dropdown" type="button">{{trans('doctors.Processes')}}<i class="fas fa-caret-down mr-1"></i></button>
                                         <div class="dropdown-menu tx-13">
-                                            <a class="dropdown-item" href="#" data-toggle="modal" data-target="#add_diagnosis{{$invoice->id}}"><i class="text-primary fa fa-stethoscope"></i>&nbsp;&nbsp;اضافة تشخيص </a>
-                                            <a class="dropdown-item" href="#" data-toggle="modal" data-target="#add_review{{$invoice->id}}"><i class="text-warning far fa-file-alt"></i>&nbsp;&nbsp;اضافة مراجعة </a>
-                                            <a class="dropdown-item" href="#" data-toggle="modal" data-target="#xray_conversion{{$invoice->id}}"><i class="text-primary fas fa-x-ray"></i>&nbsp;&nbsp;تحويل الي الاشعة </a>
-                                            <a class="dropdown-item" href="#" data-toggle="modal" data-target="#laboratorie_conversion{{$invoice->id}}"><i class="text-warning fas fa-syringe"></i>&nbsp;&nbsp;تحويل الي المختبر </a>
-                                            <a class="dropdown-item" href="#" data-toggle="modal" data-target="#delete{{$invoice->id}}"><i class="text-danger  ti-trash"></i>&nbsp;&nbsp;حذف البيانات</a>
+                                            <a class="dropdown-item" href="#" data-toggle="modal" data-target="#add_diagnosis{{$invoice->id}}"><i class="text-primary fa fa-stethoscope"></i>&nbsp;&nbsp;{{ trans('Dashboard/Doctor.AddDiagnosis') }} </a>
+                                            <a class="dropdown-item" href="#" data-toggle="modal" data-target="#add_review{{$invoice->id}}"><i class="text-warning far fa-file-alt"></i>&nbsp;&nbsp;{{ trans('Dashboard/Doctor.AddReview') }} </a>
+                                            <a class="dropdown-item" href="#" data-toggle="modal" data-target="#xray_conversion{{$invoice->id}}"><i class="text-primary fas fa-x-ray"></i>&nbsp;&nbsp;{{ trans('Dashboard/Doctor.XrayConversion') }} </a>
+                                            <a class="dropdown-item" href="#" data-toggle="modal" data-target="#laboratorie_conversion{{$invoice->id}}"><i class="text-warning fas fa-syringe"></i>&nbsp;&nbsp;{{ trans('Dashboard/Doctor.LaboratoryConversion') }} </a>
+                                            <a class="dropdown-item" href="#" data-toggle="modal" data-target="#delete{{$invoice->id}}"><i class="text-danger  ti-trash"></i>&nbsp;&nbsp;{{ trans('doctors.DeleteData') }}</a>
                                         </div>
                                     </div>
                                 </td>

--- a/resources/views/Dashboard/doctor/invoices/review_invoices.blade.php
+++ b/resources/views/Dashboard/doctor/invoices/review_invoices.blade.php
@@ -1,6 +1,6 @@
 @extends('Dashboard.layouts.master')
 @section('title')
-المراجعات
+{{ trans('Dashboard/Doctor.ReviewInvoices') }}
 @stop
 @section('css')
 <!-- Internal Data table css -->
@@ -21,7 +21,7 @@
 <div class="breadcrumb-header justify-content-between">
     <div class="my-auto">
         <div class="d-flex">
-            <h4 class="content-title mb-0 my-auto">المراجعات</h4><span class="text-muted mt-1 tx-13 mr-2 mb-0">/ الفواتير</span>
+            <h4 class="content-title mb-0 my-auto">{{ trans('Dashboard/Doctor.ReviewInvoices') }}</h4><span class="text-muted mt-1 tx-13 mr-2 mb-0">/ {{ trans('Dashboard/Doctor.Invoices') }}</span>
         </div>
     </div>
 </div>
@@ -40,17 +40,17 @@
                         <thead>
                             <tr>
                                 <th>#</th>
-                                <th>تاريخ الفاتورة</th>
-                                <th>اسم الخدمة</th>
-                                <th>اسم المريض</th>
-                                <th>سعر الخدمة</th>
-                                <th>قيمة الخصم</th>
-                                <th>نسبة الضريبة</th>
-                                <th>قيمة الضريبة</th>
-                                <th>الاجمالي مع الضريبة</th>
-                                <th>حالة الفاتورة</th>
-                                <th>تاريخ المراجعة</th>
-                                <th>العمليات</th>
+                                <th>{{ trans('Dashboard/Doctor.InvoiceDate') }}</th>
+                <th>{{ trans('Dashboard/Doctor.ServiceName') }}</th>
+                <th>{{ trans('Dashboard/Doctor.PatientName') }}</th>
+                <th>{{ trans('Dashboard/Doctor.ServicePrice') }}</th>
+                <th>{{ trans('Dashboard/Doctor.DiscountValue') }}</th>
+                <th>{{ trans('Dashboard/Doctor.TaxRate') }}</th>
+                <th>{{ trans('Dashboard/Doctor.TaxValue') }}</th>
+                <th>{{ trans('Dashboard/Doctor.TotalWithTax') }}</th>
+                <th>{{ trans('Dashboard/Doctor.InvoiceStatus') }}</th>
+                <th>{{ trans('Dashboard/Doctor.ReviewDate') }}</th>
+                <th>{{ trans('Dashboard/Doctor.Operations') }}</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -67,11 +67,11 @@
                                 <td>{{ number_format($invoice->total_with_tax, 2) }}</td>
                                 <td>
                                     @if($invoice->invoice_status == 1)
-                                    <span class="badge badge-danger">تحت الاجراء</span>
+                                    <span class="badge badge-danger">{{ trans('Dashboard/Doctor.UnderProcessing') }}</span>
                                     @elseif($invoice->invoice_status == 2)
-                                    <span class="badge badge-warning">مراجعة</span>
+                                    <span class="badge badge-warning">{{ trans('Dashboard/Doctor.Review') }}</span>
                                     @else
-                                    <span class="badge badge-success">مكتملة</span>
+                                    <span class="badge badge-success">{{ trans('Dashboard/Doctor.Completed') }}</span>
                                     @endif
                                 </td>
 
@@ -80,11 +80,11 @@
                                     <div class="dropdown">
                                         <button aria-expanded="false" aria-haspopup="true" class="btn ripple btn-outline-primary btn-sm" data-toggle="dropdown" type="button">{{trans('doctors.Processes')}}<i class="fas fa-caret-down mr-1"></i></button>
                                         <div class="dropdown-menu tx-13">
-                                            <a class="dropdown-item" href="#" data-toggle="modal" data-target="#add_diagnosis{{$invoice->id}}"><i class="text-primary fa fa-stethoscope"></i>&nbsp;&nbsp;اضافة تشخيص </a>
-                                            <a class="dropdown-item" href="#" data-toggle="modal" data-target="#add_review{{$invoice->id}}"><i class="text-warning far fa-file-alt"></i>&nbsp;&nbsp;اضافة مراجعة </a>
-                                            <a class="dropdown-item" href="#" data-toggle="modal" data-target="#xray_conversion{{$invoice->id}}"><i class="text-primary fas fa-x-ray"></i>&nbsp;&nbsp;تحويل الي الاشعة </a>
-                                            <a class="dropdown-item" href="#" data-toggle="modal" data-target="#laboratorie_conversion{{$invoice->id}}"><i class="text-warning fas fa-syringe"></i>&nbsp;&nbsp;تحويل الي المختبر </a>
-                                            <a class="dropdown-item" href="#" data-toggle="modal" data-target="#delete{{$invoice->id}}"><i class="text-danger  ti-trash"></i>&nbsp;&nbsp;حذف البيانات</a>
+                                            <a class="dropdown-item" href="#" data-toggle="modal" data-target="#add_diagnosis{{$invoice->id}}"><i class="text-primary fa fa-stethoscope"></i>&nbsp;&nbsp;{{ trans('Dashboard/Doctor.AddDiagnosis') }} </a>
+                                            <a class="dropdown-item" href="#" data-toggle="modal" data-target="#add_review{{$invoice->id}}"><i class="text-warning far fa-file-alt"></i>&nbsp;&nbsp;{{ trans('Dashboard/Doctor.AddReview') }} </a>
+                                            <a class="dropdown-item" href="#" data-toggle="modal" data-target="#xray_conversion{{$invoice->id}}"><i class="text-primary fas fa-x-ray"></i>&nbsp;&nbsp;{{ trans('Dashboard/Doctor.XrayConversion') }} </a>
+                                            <a class="dropdown-item" href="#" data-toggle="modal" data-target="#laboratorie_conversion{{$invoice->id}}"><i class="text-warning fas fa-syringe"></i>&nbsp;&nbsp;{{ trans('Dashboard/Doctor.LaboratoryConversion') }} </a>
+                                            <a class="dropdown-item" href="#" data-toggle="modal" data-target="#delete{{$invoice->id}}"><i class="text-danger  ti-trash"></i>&nbsp;&nbsp;{{ trans('doctors.DeleteData') }}</a>
                                         </div>
                                     </div>
                                 </td>


### PR DESCRIPTION
## Summary
- replace static doctor dashboard metrics with translation strings
- add translation-based table headers and actions for doctor invoices
- introduce Arabic and English translations for doctor dashboard and invoices

## Testing
- `php artisan test` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b617b63098832894f5282da5502421