### PR TITLE
Add translations for insurance service status

### DIFF
--- a/resources/lang/ar/insurance.php
+++ b/resources/lang/ar/insurance.php
@@ -28,6 +28,8 @@ return [
     "close" => 'اغلاق',
     "Deleted" => 'هل انت متأكد من عمليه الحذف ؟',
     "Title_deleted" => 'حذف البيانات',
-
-
+    "AllServices" => 'جميع الخدمات',
+    "Active" => 'مفعل',
+    "Inactive" => 'غير مفعل',
+    "ActivationStatus" => 'حالة التفعيل',
 ];

--- a/resources/lang/en/insurance.php
+++ b/resources/lang/en/insurance.php
@@ -1,0 +1,23 @@
+<?php
+
+return array (
+  'Insurance' => 'Insurance Companies',
+  'Add_Insurance' => 'Add Insurance Company',
+  'Company_name' => 'Company Name',
+  'Company_code' => 'Company Code',
+  'discount_percentage' => 'Patient Discount Percentage',
+  'Insurance_bearing_percentage' => 'Insurance Bearing Percentage',
+  'notes' => 'Notes',
+  'status' => 'Status',
+  'Processes' => 'Processes',
+  'Determine_percentage' => 'Determine Insurance Percentage',
+  'save' => 'Save Data',
+  'edit_Insurance' => 'Edit Insurance Company Data',
+  'close' => 'Close',
+  'Deleted' => 'Are you sure about the deletion process?',
+  'Title_deleted' => 'Delete Data',
+  'AllServices' => 'All Services',
+  'Active' => 'Active',
+  'Inactive' => 'Inactive',
+  'ActivationStatus' => 'Activation Status',
+);

--- a/resources/views/Dashboard/insurance/create.blade.php
+++ b/resources/views/Dashboard/insurance/create.blade.php
@@ -11,7 +11,7 @@
 <div class="breadcrumb-header justify-content-between">
     <div class="my-auto">
         <div class="d-flex">
-            <h4 class="content-title mb-0 my-auto">جميع الخدمات</h4><span class="text-muted mt-1 tx-13 mr-2 mb-0">/ {{trans('insurance.Insurance')}}</span>
+            <h4 class="content-title mb-0 my-auto">{{ trans('insurance.AllServices') }}</h4><span class="text-muted mt-1 tx-13 mr-2 mb-0">/ {{trans('insurance.Insurance')}}</span>
         </div>
     </div>
 </div>

--- a/resources/views/Dashboard/insurance/edit.blade.php
+++ b/resources/views/Dashboard/insurance/edit.blade.php
@@ -12,7 +12,7 @@
     <div class="breadcrumb-header justify-content-between">
         <div class="my-auto">
             <div class="d-flex">
-                <h4 class="content-title mb-0 my-auto">{{trans('main-sidebar_trans.Services')}}</h4><span
+                <h4 class="content-title mb-0 my-auto">{{ trans('insurance.AllServices') }}</h4><span
                     class="text-muted mt-1 tx-13 mr-2 mb-0">/ {{trans('insurance.Insurance')}}</span>
             </div>
         </div>
@@ -92,7 +92,7 @@
 
                         <div class="row">
                             <div class="col">
-                                <label>حالة التفعيل</label>
+                                <label>{{ trans('insurance.ActivationStatus') }}</label>
                                  &nbsp;
                                 <input name="status" {{$insurances->status == 1 ? 'checked' : ''}} value="1" type="checkbox" class="form-check-input" id="exampleCheck1">
                             </div>

--- a/resources/views/Dashboard/insurance/index.blade.php
+++ b/resources/views/Dashboard/insurance/index.blade.php
@@ -11,7 +11,7 @@
     <div class="breadcrumb-header justify-content-between">
         <div class="my-auto">
             <div class="d-flex">
-                <h4 class="content-title mb-0 my-auto">{{trans('main-sidebar_trans.Services')}}</h4><span class="text-muted mt-1 tx-13 mr-2 mb-0">/ {{trans('main-sidebar_trans.Insurance')}}</span>
+                <h4 class="content-title mb-0 my-auto">{{ trans('insurance.AllServices') }}</h4><span class="text-muted mt-1 tx-13 mr-2 mb-0">/ {{trans('main-sidebar_trans.Insurance')}}</span>
             </div>
         </div>
     </div>
@@ -38,7 +38,7 @@
                                 <th >{{trans('insurance.Company_name')}}</th>
                                 <th >{{trans('insurance.discount_percentage')}}</th>
                                 <th >{{trans('insurance.Insurance_bearing_percentage')}}</th>
-                                <th >{{trans('insurance.status')}}</th>
+                                <th >{{ trans('insurance.ActivationStatus') }}</th>
                                 <th >{{trans('insurance.notes')}}</th>
                                 <th >{{trans('insurance.Processes')}}</th>
                             </tr>
@@ -51,7 +51,7 @@
                                     <td>{{$insurance->name}}</td>
                                     <td>{{$insurance->discount_percentage}}</td>
                                     <td>{{$insurance->Company_rate}}</td>
-                                    <td class="{{$insurance->status == 1 ? 'bg-success':'bg-danger'}}">{{$insurance->status == 1 ? 'مفعل' : 'غير مفعل'}}</td>
+                                    <td class="{{$insurance->status == 1 ? 'bg-success':'bg-danger'}}">{{$insurance->status == 1 ? trans('insurance.Active') : trans('insurance.Inactive')}}</td>
                                     <td>{{$insurance->notes}}</td>
                                     <td>
                                         <a href="{{route('insurance.edit',$insurance->id)}}" class="btn btn-sm btn-success"><i class="fas fa-edit"></i></a>


### PR DESCRIPTION
## Summary
- localize insurance breadcrumbs with `insurance.AllServices`
- translate activation status states and label
- provide English translations for insurance strings

## Testing
- `vendor/bin/phpunit` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b617b7ef188328ad9c016349e1f9df