### PR TITLE
Add translation support for laboratory views

### DIFF
--- a/resources/lang/ar/Dashboard/Laboratorie.php
+++ b/resources/lang/ar/Dashboard/Laboratorie.php
@@ -1,0 +1,15 @@
+<?php
+
+return [
+    'Laboratory' => 'المختبر',
+    'Invoices' => 'الكشوفات',
+    'ServiceName' => 'اسم الخدمة',
+    'DoctorName' => 'اسم الدكتور',
+    'LabEmployeeName' => 'اسم موظف المختبر',
+    'CaseStatus' => 'حالة الكشف',
+    'ViewAnalysis' => 'عرض التحليل',
+    'LabNotes' => 'ملاحظات موظف المختبر',
+    'Completed' => 'مكتملة',
+    'NotCompleted' => 'غير مكتملة',
+];
+

--- a/resources/lang/en/Dashboard/Laboratorie.php
+++ b/resources/lang/en/Dashboard/Laboratorie.php
@@ -1,0 +1,15 @@
+<?php
+
+return [
+    'Laboratory' => 'Laboratory',
+    'Invoices' => 'Invoices',
+    'ServiceName' => 'Service Name',
+    'DoctorName' => 'Doctor Name',
+    'LabEmployeeName' => 'Lab Employee Name',
+    'CaseStatus' => 'Case Status',
+    'ViewAnalysis' => 'View Analysis',
+    'LabNotes' => 'Lab Employee Notes',
+    'Completed' => 'Completed',
+    'NotCompleted' => 'Not Completed',
+];
+

--- a/resources/views/Dashboard/laboratorie/index.blade.php
+++ b/resources/views/Dashboard/laboratorie/index.blade.php
@@ -1,6 +1,6 @@
 @extends('Dashboard.layouts.master')
 @section('title')
-    الكشوفات
+    {{ trans('Dashboard/Laboratorie.Invoices') }}
 @stop
 @section('css')
 <link href="{{URL::asset('dashboard/plugins/notify/css/notifIt.css')}}" rel="stylesheet" />
@@ -10,7 +10,7 @@
 <div class="breadcrumb-header justify-content-between">
     <div class="my-auto">
         <div class="d-flex">
-            <h4 class="content-title mb-0 my-auto">المختبر</h4><span class="text-muted mt-1 tx-13 mr-2 mb-0">/ الكشوفات</span>
+            <h4 class="content-title mb-0 my-auto">{{ trans('Dashboard/Laboratorie.Laboratory') }}</h4><span class="text-muted mt-1 tx-13 mr-2 mb-0">/ {{ trans('Dashboard/Laboratorie.Invoices') }}</span>
         </div>
     </div>
 </div>
@@ -27,11 +27,11 @@
                         <thead>
                             <tr>
                                 <th>#</th>
-                                <th>اسم الخدمة</th>
-                                <th>اسم الدكتور</th>
-                                <th>اسم موظف المختبر</th>
-                                <th>حالة الكشف</th>
-                                <th>عرض التحليل</th>
+                                <th>{{ trans('Dashboard/Laboratorie.ServiceName') }}</th>
+                                <th>{{ trans('Dashboard/Laboratorie.DoctorName') }}</th>
+                                <th>{{ trans('Dashboard/Laboratorie.LabEmployeeName') }}</th>
+                                <th>{{ trans('Dashboard/Laboratorie.CaseStatus') }}</th>
+                                <th>{{ trans('Dashboard/Laboratorie.ViewAnalysis') }}</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -42,9 +42,9 @@
                                 <td>{{$lab->doctor->name}}</td>
                                 <td>{{$lab->employee->name}}</td>
                                 @if($lab->case == 0)
-                                <td class="text-danger">غير مكتملة</td>
+                                <td class="text-danger">{{ trans('Dashboard/Laboratorie.NotCompleted') }}</td>
                                 @else
-                                <td class="text-success">مكتملة</td>
+                                <td class="text-success">{{ trans('Dashboard/Laboratorie.Completed') }}</td>
                                 @endif
                                 <td>
                                     <a class="btn btn-sm btn-warning" href="{{ route('admin.laboratorie.show', $lab->id) }}"><i class="fas fa-binoculars"></i></a>

--- a/resources/views/Dashboard/laboratorie/show.blade.php
+++ b/resources/views/Dashboard/laboratorie/show.blade.php
@@ -1,6 +1,6 @@
 @extends('Dashboard.layouts.master')
 @section('title')
-    الكشوفات
+    {{ trans('Dashboard/Laboratorie.Invoices') }}
 @stop
 @section('css')
 
@@ -10,7 +10,7 @@
     <div class="breadcrumb-header justify-content-between">
         <div class="my-auto">
             <div class="d-flex">
-                <h4 class="content-title mb-0 my-auto">صور التحاليل</h4><span class="text-muted mt-1 tx-13 mr-2 mb-0">/ {{$laboratorie->Patient->name}}</span>
+                <h4 class="content-title mb-0 my-auto">{{ trans('Dashboard/Laboratorie.ViewAnalysis') }}</h4><span class="text-muted mt-1 tx-13 mr-2 mb-0">/ {{$laboratorie->Patient->name}}</span>
             </div>
         </div>
     </div>
@@ -18,7 +18,7 @@
 @endsection
 @section('content')
     <div class="form-group">
-        <label for="exampleFormControlTextarea1">ملاحظات موظف المختبر</label>
+        <label for="exampleFormControlTextarea1">{{ trans('Dashboard/Laboratorie.LabNotes') }}</label>
         <textarea readonly class="form-control" id="exampleFormControlTextarea1" rows="3">{{$laboratorie->description_employee}}</textarea>
     </div>
     <!-- Gallery -->
@@ -27,7 +27,7 @@
             @foreach($laboratorie->images as $image)
                 <li class="col-sm-6 col-lg-4" data-responsive="{{URL::asset('Dashboard/img/laboratories/'.$image->filename)}}" data-src="{{URL::asset('Dashboard/img/laboratories/'.$image->filename)}}">
                     <a href="#">
-                        <img width="50px" height="350px" class="img-responsive" src="{{URL::asset('Dashboard/img/laboratories/'.$image->filename)}}" alt="NoImg">
+                        <img width="50px" height="350px" class="img-responsive" src="{{URL::asset('Dashboard/img/laboratories/'.$image->filename)}}" alt="{{ trans('Dashboard/LaboratorieEmployee.NoImage') }}">
                     </a>
                 </li>
             @endforeach


### PR DESCRIPTION
## Summary
- replace hardcoded text in laboratory index and detail views with translation calls
- add English and Arabic translation files for laboratory-related labels

## Testing
- `./vendor/bin/phpunit` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b617ba3f808328bce4c81e71ec1a49