### PR TITLE
Localize laboratorie employee views

### DIFF
--- a/resources/lang/ar/Dashboard/LaboratorieEmployee.php
+++ b/resources/lang/ar/Dashboard/LaboratorieEmployee.php
@@ -1,6 +1,16 @@
 <?php
 
 return [
+    'EmployeeList' => 'قائمة الموظفين',
+    'AddEmployee' => 'اضافة موظف جديد',
+    'EditEmployee' => 'تعديل بيانات موظف',
+    'DeleteEmployee' => 'حذف بيانات موظف',
+    'EmployeeName' => 'الاسم',
+    'Email' => 'البريد الالكتروني',
+    'Password' => 'كلمة المرور',
+    'CreatedAt' => 'تاريخ الاضافة',
+    'Close' => 'اغلاق',
+    'Submit' => 'تاكيد',
     'DashboardTitle' => 'لوحة تحكم موظفي المختبر',
     'WelcomeBack' => 'مرحبا بعودتك مرة اخري',
     'TotalInvoices' => 'اجمالي عدد الفواتير',

--- a/resources/lang/en/Dashboard/LaboratorieEmployee.php
+++ b/resources/lang/en/Dashboard/LaboratorieEmployee.php
@@ -1,6 +1,16 @@
 <?php
 
 return [
+    'EmployeeList' => 'Employee List',
+    'AddEmployee' => 'Add Employee',
+    'EditEmployee' => 'Edit Employee',
+    'DeleteEmployee' => 'Delete Employee',
+    'EmployeeName' => 'Employee Name',
+    'Email' => 'Email',
+    'Password' => 'Password',
+    'CreatedAt' => 'Created At',
+    'Close' => 'Close',
+    'Submit' => 'Submit',
     'DashboardTitle' => 'Laboratory Employee Dashboard',
     'WelcomeBack' => 'Welcome back again',
     'TotalInvoices' => 'Total invoices',

--- a/resources/views/Dashboard/laboratorie_employee/add.blade.php
+++ b/resources/views/Dashboard/laboratorie_employee/add.blade.php
@@ -3,7 +3,7 @@
     <div class="modal-dialog" role="document">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title" id="exampleModalLabel">اضافة موظف جديد</h5>
+                <h5 class="modal-title" id="exampleModalLabel">{{ trans('Dashboard/LaboratorieEmployee.AddEmployee') }}</h5>
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                     <span aria-hidden="true">&times;</span>
                 </button>
@@ -11,19 +11,19 @@
             <form action="{{ route('laboratorie_employee.store') }}" method="post" autocomplete="off">
                 @csrf
                 <div class="modal-body">
-                    <label for="exampleInputPassword1">الاسم</label>
+                    <label for="exampleInputPassword1">{{ trans('Dashboard/LaboratorieEmployee.EmployeeName') }}</label>
                     <input type="text" name="name" class="form-control"><br>
 
-                    <label for="exampleInputPassword1">البريد الالكتروني</label>
+                    <label for="exampleInputPassword1">{{ trans('Dashboard/LaboratorieEmployee.Email') }}</label>
                     <input type="email" name="email" class="form-control"><br>
 
-                    <label for="exampleInputPassword1">كلمة المرور</label>
+                    <label for="exampleInputPassword1">{{ trans('Dashboard/LaboratorieEmployee.Password') }}</label>
                     <input type="password" name="password" class="form-control"><br>
 
                 </div>
                 <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-dismiss="modal">{{trans('Dashboard/sections_trans.Close')}}</button>
-                    <button type="submit" class="btn btn-primary">{{trans('Dashboard/sections_trans.submit')}}</button>
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">{{ trans('Dashboard/LaboratorieEmployee.Close') }}</button>
+                    <button type="submit" class="btn btn-primary">{{ trans('Dashboard/LaboratorieEmployee.Submit') }}</button>
                 </div>
             </form>
         </div>

--- a/resources/views/Dashboard/laboratorie_employee/delete.blade.php
+++ b/resources/views/Dashboard/laboratorie_employee/delete.blade.php
@@ -4,7 +4,7 @@
     <div class="modal-dialog" role="document">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title" id="exampleModalLabel">حذف بيانات موظف</h5>
+                <h5 class="modal-title" id="exampleModalLabel">{{ trans('Dashboard/LaboratorieEmployee.DeleteEmployee') }}</h5>
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                     <span aria-hidden="true">&times;</span>
                 </button>
@@ -16,8 +16,8 @@
                 <h5>{{trans('Dashboard/sections_trans.Warning')}} {{$laboratorie_employee->name}}</h5>
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-dismiss="modal">{{trans('Dashboard/sections_trans.Close')}}</button>
-                <button type="submit" class="btn btn-danger">{{trans('Dashboard/sections_trans.submit')}}</button>
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">{{ trans('Dashboard/LaboratorieEmployee.Close') }}</button>
+                <button type="submit" class="btn btn-danger">{{ trans('Dashboard/LaboratorieEmployee.Submit') }}</button>
             </div>
             </form>
         </div>

--- a/resources/views/Dashboard/laboratorie_employee/edit.blade.php
+++ b/resources/views/Dashboard/laboratorie_employee/edit.blade.php
@@ -4,7 +4,7 @@
     <div class="modal-dialog" role="document">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title" id="exampleModalLabel">تعديل بيانات موظف</h5>
+                <h5 class="modal-title" id="exampleModalLabel">{{ trans('Dashboard/LaboratorieEmployee.EditEmployee') }}</h5>
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                     <span aria-hidden="true">&times;</span>
                 </button>
@@ -14,18 +14,18 @@
                 {{ csrf_field() }}
                 @csrf
                 <div class="modal-body">
-                    <label for="exampleInputPassword1">الاسم</label>
+                    <label for="exampleInputPassword1">{{ trans('Dashboard/LaboratorieEmployee.EmployeeName') }}</label>
                     <input type="text" value="{{$laboratorie_employee->name}}" name="name" class="form-control"><br>
 
-                    <label for="exampleInputPassword1">البريد الالكتروني</label>
+                    <label for="exampleInputPassword1">{{ trans('Dashboard/LaboratorieEmployee.Email') }}</label>
                     <input type="email" value="{{$laboratorie_employee->email}}" name="email" class="form-control"><br>
 
-                    <label for="exampleInputPassword1">كلمة المرور</label>
+                    <label for="exampleInputPassword1">{{ trans('Dashboard/LaboratorieEmployee.Password') }}</label>
                     <input type="password" name="password" class="form-control" autocomplete="new-password">
                 </div>
                 <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-dismiss="modal">{{trans('Dashboard/sections_trans.Close')}}</button>
-                    <button type="submit" class="btn btn-primary">{{trans('Dashboard/sections_trans.submit')}}</button>
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">{{ trans('Dashboard/LaboratorieEmployee.Close') }}</button>
+                    <button type="submit" class="btn btn-primary">{{ trans('Dashboard/LaboratorieEmployee.Submit') }}</button>
                 </div>
             </form>
         </div>

--- a/resources/views/Dashboard/laboratorie_employee/index.blade.php
+++ b/resources/views/Dashboard/laboratorie_employee/index.blade.php
@@ -1,6 +1,6 @@
 @extends('Dashboard.layouts.master')
 @section('title')
-   قائمة الموظفين
+   {{ trans('Dashboard/LaboratorieEmployee.EmployeeList') }}
 @stop
 @section('css')
     <!-- Internal Data table css -->
@@ -13,7 +13,7 @@
 				<div class="breadcrumb-header justify-content-between">
 					<div class="my-auto">
 						<div class="d-flex">
-							<h4 class="content-title mb-0 my-auto">المتخبر</h4><span class="text-muted mt-1 tx-13 mr-2 mb-0">/ قائمة الموظفين</span>
+                                                        <h4 class="content-title mb-0 my-auto">المتخبر</h4><span class="text-muted mt-1 tx-13 mr-2 mb-0">/ {{ trans('Dashboard/LaboratorieEmployee.EmployeeList') }}</span>
 						</div>
 					</div>
 				</div>
@@ -29,7 +29,7 @@
                                 <div class="card-header pb-0">
                                     <div class="d-flex justify-content-between">
                                         <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#add">
-                                           اضافة موظف جديد
+                                           {{ trans('Dashboard/LaboratorieEmployee.AddEmployee') }}
                                         </button>
                                     </div>
                                 </div>
@@ -39,10 +39,10 @@
                                             <thead>
                                             <tr>
                                                 <th>#</th>
-                                                <th>الاسم</th>
-                                                <th >البريد الالكتروني</th>
-                                                <th>تاريخ الاضافة</th>
-                                                <th >العمليات</th>
+                                                <th>{{ trans('Dashboard/LaboratorieEmployee.EmployeeName') }}</th>
+                                                <th>{{ trans('Dashboard/LaboratorieEmployee.Email') }}</th>
+                                                <th>{{ trans('Dashboard/LaboratorieEmployee.CreatedAt') }}</th>
+                                                <th>{{ trans('Dashboard/LaboratorieEmployee.Operations') }}</th>
                                             </tr>
                                             </thead>
                                             <tbody>


### PR DESCRIPTION
## Summary
- Replace hard-coded Arabic text in laboratorie employee views with translation helpers
- Add English and Arabic translations for laboratorie employee UI labels

## Testing
- `./vendor/bin/phpunit` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b617bbb1788328b225b3ee3d9c59ed