### PR TITLE
Use translation for patient date placeholder

### DIFF
--- a/resources/lang/ar/Patients.php
+++ b/resources/lang/ar/Patients.php
@@ -10,6 +10,7 @@ return array (
   'name' => 'اسم المريض',
   'email' => 'البريد الالكتروني',
   'date_birth' => 'تاريخ الميلاد',
+  'DatePlaceholder' => 'YYYY-MM-DD',
   'phone' => 'رقم الهاتف',
   'gender' => 'الجنس',
   'blood_group' => 'فصيلة الدم',

--- a/resources/lang/en/Patients.php
+++ b/resources/lang/en/Patients.php
@@ -10,6 +10,7 @@ return array (
   'name' => 'Patient Name',
   'email' => 'Email',
   'date_birth' => 'Date of Birth',
+  'DatePlaceholder' => 'YYYY-MM-DD',
   'phone' => 'Phone',
   'gender' => 'Gender',
   'blood_group' => 'Blood Group',

--- a/resources/views/Dashboard/Patients/create.blade.php
+++ b/resources/views/Dashboard/Patients/create.blade.php
@@ -40,7 +40,7 @@
 
                         <div class="col">
                             <label>{{ trans('Patients.date_birth') }}</label>
-                            <input class="form-control fc-datepicker" name="Date_Birth" placeholder="YYYY-MM-DD"
+                            <input class="form-control fc-datepicker" name="Date_Birth" placeholder="{{ trans('Patients.DatePlaceholder') }}"
                              type="text" required>
                         </div>
 


### PR DESCRIPTION
## Summary
- use translatable placeholder for patient birth date
- add DatePlaceholder translation key in Arabic and English

## Testing
- `composer install`
- `./vendor/bin/phpunit` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b61ae0f30c832890ed0b0864ec8a1e