### PR TITLE
Localize sidebar menus for doctor, patient, and staff dashboards

### DIFF
--- a/resources/lang/ar/Sidebar/Doctor.php
+++ b/resources/lang/ar/Sidebar/Doctor.php
@@ -1,0 +1,15 @@
+<?php
+
+return [
+    'Invoices' => 'كشوفات الدكتور',
+    'InvoicesList' => 'قائمة الكشوفات',
+    'CompletedInvoices' => 'قائمة الكشوفات المكتملة',
+    'ReviewInvoices' => 'قائمة المراجعات',
+    'Appointments' => 'المواعيد',
+    'AppointmentsList' => 'قائمة المواعيد',
+    'ExpiredAppointments' => 'المواعيد المنتهية',
+    'Chats' => 'المحادثات',
+    'PatientsList' => 'قائمة المرضي',
+    'RecentChats' => 'المحادثات الاخيرة',
+];
+

--- a/resources/lang/ar/Sidebar/LaboratorieEmployee.php
+++ b/resources/lang/ar/Sidebar/LaboratorieEmployee.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'Invoices' => 'كشوفات الاشعة',
+    'InvoicesList' => 'قائمة الكشوفات',
+    'CompletedInvoices' => 'قائمة الكشوفات المكتملة',
+];
+

--- a/resources/lang/ar/Sidebar/Patient.php
+++ b/resources/lang/ar/Sidebar/Patient.php
@@ -1,0 +1,16 @@
+<?php
+
+return [
+    'Operations' => 'عمليات المريض',
+    'InvoicesList' => 'قائمة الفواتير',
+    'Records' => 'الكشوفات',
+    'Laboratory' => 'المختبر',
+    'Rays' => 'الاشعة',
+    'Appointments' => 'المواعيد',
+    'AppointmentsList' => 'قائمة المواعيد',
+    'ExpiredAppointments' => 'المواعيد المنتهية',
+    'Chats' => 'المحادثات',
+    'DoctorsList' => 'قائمة الاطباء',
+    'RecentChats' => 'المحادثات الاخيرة',
+];
+

--- a/resources/lang/ar/Sidebar/RayEmployee.php
+++ b/resources/lang/ar/Sidebar/RayEmployee.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'Invoices' => 'كشوفات الاشعة',
+    'InvoicesList' => 'قائمة الكشوفات',
+    'CompletedInvoices' => 'قائمة الكشوفات المكتملة',
+];
+

--- a/resources/lang/en/Sidebar/Doctor.php
+++ b/resources/lang/en/Sidebar/Doctor.php
@@ -1,0 +1,15 @@
+<?php
+
+return [
+    'Invoices' => 'Doctor Invoices',
+    'InvoicesList' => 'Invoices List',
+    'CompletedInvoices' => 'Completed Invoices',
+    'ReviewInvoices' => 'Review Invoices',
+    'Appointments' => 'Appointments',
+    'AppointmentsList' => 'Appointments List',
+    'ExpiredAppointments' => 'Expired Appointments',
+    'Chats' => 'Chats',
+    'PatientsList' => 'Patients List',
+    'RecentChats' => 'Recent Chats',
+];
+

--- a/resources/lang/en/Sidebar/LaboratorieEmployee.php
+++ b/resources/lang/en/Sidebar/LaboratorieEmployee.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'Invoices' => 'Laboratory Invoices',
+    'InvoicesList' => 'Invoices List',
+    'CompletedInvoices' => 'Completed Invoices',
+];
+

--- a/resources/lang/en/Sidebar/Patient.php
+++ b/resources/lang/en/Sidebar/Patient.php
@@ -1,0 +1,16 @@
+<?php
+
+return [
+    'Operations' => 'Patient Operations',
+    'InvoicesList' => 'Invoices List',
+    'Records' => 'Records',
+    'Laboratory' => 'Laboratory',
+    'Rays' => 'Rays',
+    'Appointments' => 'Appointments',
+    'AppointmentsList' => 'Appointments List',
+    'ExpiredAppointments' => 'Expired Appointments',
+    'Chats' => 'Chats',
+    'DoctorsList' => 'Doctors List',
+    'RecentChats' => 'Recent Chats',
+];
+

--- a/resources/lang/en/Sidebar/RayEmployee.php
+++ b/resources/lang/en/Sidebar/RayEmployee.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'Invoices' => 'Ray Invoices',
+    'InvoicesList' => 'Invoices List',
+    'CompletedInvoices' => 'Completed Invoices',
+];
+

--- a/resources/views/Dashboard/layouts/main-sidebar/doctor-sidebar-main.blade.php
+++ b/resources/views/Dashboard/layouts/main-sidebar/doctor-sidebar-main.blade.php
@@ -44,11 +44,11 @@ $folder = 'doctors';
 						<path d="M0 0h24v24H0V0z" fill="none" />
 						<path d="M19 5H5v14h14V5zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z" opacity=".3" />
 						<path d="M3 5v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.1 0-2 .9-2 2zm2 0h14v14H5V5zm2 5h2v7H7zm4-3h2v10h-2zm4 6h2v4h-2z" />
-					</svg><span class="side-menu__label">كشوفات الدكتور</span><i class="angle fe fe-chevron-down"></i></a>
+                                        </svg><span class="side-menu__label">{{ trans('Sidebar/Doctor.Invoices') }}</span><i class="angle fe fe-chevron-down"></i></a>
 				<ul class="slide-menu">
-					<li><a class="slide-item" href="{{ route('invoices.index') }}">قائمة الكشوفات</a></li>
-					<li><a class="slide-item" href="{{route('completedInvoices')}}">قائمة الكشوفات المكتملة</a></li>
-					<li><a class="slide-item" href="{{route('reviewInvoices')}}">قائمة المراجعات</a></li>
+                                        <li><a class="slide-item" href="{{ route('invoices.index') }}">{{ trans('Sidebar/Doctor.InvoicesList') }}</a></li>
+                                        <li><a class="slide-item" href="{{route('completedInvoices')}}">{{ trans('Sidebar/Doctor.CompletedInvoices') }}</a></li>
+                                        <li><a class="slide-item" href="{{route('reviewInvoices')}}">{{ trans('Sidebar/Doctor.ReviewInvoices') }}</a></li>
 				</ul>
 			</li>
 
@@ -57,25 +57,25 @@ $folder = 'doctors';
 						<path d="M0 0h24v24H0V0z" fill="none" />
 						<path d="M19 5H5v14h14V5zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z" opacity=".3" />
 						<path d="M3 5v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.1 0-2 .9-2 2zm2 0h14v14H5V5zm2 5h2v7H7zm4-3h2v10h-2zm4 6h2v4h-2z" />
-					</svg><span class="side-menu__label">المواعيد</span><i class="angle fe fe-chevron-down"></i></a>
+                                        </svg><span class="side-menu__label">{{ trans('Sidebar/Doctor.Appointments') }}</span><i class="angle fe fe-chevron-down"></i></a>
 				<ul class="slide-menu">
-					<li><a class="slide-item" href="{{ route('doctor.appointments') }}">قائمة المواعيد</a></li>
-					<li><a class="slide-item" href="{{ route('doctor.appointments.expired') }}">المواعيد المنتهية</a></li>
+                                        <li><a class="slide-item" href="{{ route('doctor.appointments') }}">{{ trans('Sidebar/Doctor.AppointmentsList') }}</a></li>
+                                        <li><a class="slide-item" href="{{ route('doctor.appointments.expired') }}">{{ trans('Sidebar/Doctor.ExpiredAppointments') }}</a></li>
 				</ul>
 			</li>
 
 
-			<!-- <li class="slide">
-				<a class="side-menu__item" data-toggle="slide" href="{{ url('/' . $page='#') }}"><svg xmlns="http://www.w3.org/2000/svg" class="side-menu__icon" viewBox="0 0 24 24">
-						<path d="M0 0h24v24H0V0z" fill="none" />
-						<path d="M19 5H5v14h14V5zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z" opacity=".3" />
-						<path d="M3 5v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.1 0-2 .9-2 2zm2 0h14v14H5V5zm2 5h2v7H7zm4-3h2v10h-2zm4 6h2v4h-2z" />
-					</svg><span class="side-menu__label">المحادثات</span><i class="angle fe fe-chevron-down"></i></a>
-				<ul class="slide-menu">
-					<li><a class="slide-item" href="{{route('list.patients')}}">قائمة المرضي</a></li>
-					<li><a class="slide-item" href="{{route('chat.patients')}}">المحادثات الاخيرة</a></li>
-				</ul>
-			</li> -->
+                        <!-- <li class="slide">
+                                <a class="side-menu__item" data-toggle="slide" href="{{ url('/' . $page='#') }}"><svg xmlns="http://www.w3.org/2000/svg" class="side-menu__icon" viewBox="0 0 24 24">
+                                                <path d="M0 0h24v24H0V0z" fill="none" />
+                                                <path d="M19 5H5v14h14V5zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z" opacity=".3" />
+                                                <path d="M3 5v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.1 0-2 .9-2 2zm2 0h14v14H5V5zm2 5h2v7H7zm4-3h2v10h-2zm4 6h2v4h-2z" />
+                                        </svg><span class="side-menu__label">{{ trans('Sidebar/Doctor.Chats') }}</span><i class="angle fe fe-chevron-down"></i></a>
+                                <ul class="slide-menu">
+                                        <li><a class="slide-item" href="{{route('list.patients')}}">{{ trans('Sidebar/Doctor.PatientsList') }}</a></li>
+                                        <li><a class="slide-item" href="{{route('chat.patients')}}">{{ trans('Sidebar/Doctor.RecentChats') }}</a></li>
+                                </ul>
+                        </li> -->
 		</ul>
 	</div>
 </aside>

--- a/resources/views/Dashboard/layouts/main-sidebar/laboratorie_employee-sidebar-main.blade.php
+++ b/resources/views/Dashboard/layouts/main-sidebar/laboratorie_employee-sidebar-main.blade.php
@@ -45,10 +45,10 @@ $folder = 'laboratorie_employees';
 						<path d="M0 0h24v24H0V0z" fill="none" />
 						<path d="M19 5H5v14h14V5zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z" opacity=".3" />
 						<path d="M3 5v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.1 0-2 .9-2 2zm2 0h14v14H5V5zm2 5h2v7H7zm4-3h2v10h-2zm4 6h2v4h-2z" />
-					</svg><span class="side-menu__label">كشوفات الاشعة </span><i class="angle fe fe-chevron-down"></i></a>
+                                        </svg><span class="side-menu__label">{{ trans('Sidebar/LaboratorieEmployee.Invoices') }}</span><i class="angle fe fe-chevron-down"></i></a>
 				<ul class="slide-menu">
-					<li><a class="slide-item" href="{{ route('invoices_laboratorie_employee.index') }}">قائمة الكشوفات</a></li>
-					<li><a class="slide-item" href="{{route('laboratorie_completed_invoices')}}">قائمة الكشوفات المكتملة</a></li>
+                                        <li><a class="slide-item" href="{{ route('invoices_laboratorie_employee.index') }}">{{ trans('Sidebar/LaboratorieEmployee.InvoicesList') }}</a></li>
+                                        <li><a class="slide-item" href="{{route('laboratorie_completed_invoices')}}">{{ trans('Sidebar/LaboratorieEmployee.CompletedInvoices') }}</a></li>
 				</ul>
 			</li>
 		</ul>

--- a/resources/views/Dashboard/layouts/main-sidebar/patient-sidebar-main.blade.php
+++ b/resources/views/Dashboard/layouts/main-sidebar/patient-sidebar-main.blade.php
@@ -45,12 +45,12 @@ $folder = 'patients';
                         <path d="M0 0h24v24H0V0z" fill="none" />
                         <path d="M19 5H5v14h14V5zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z" opacity=".3" />
                         <path d="M3 5v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.1 0-2 .9-2 2zm2 0h14v14H5V5zm2 5h2v7H7zm4-3h2v10h-2zm4 6h2v4h-2z" />
-                    </svg><span class="side-menu__label">عمليات المريض</span><i class="angle fe fe-chevron-down"></i></a>
+                    </svg><span class="side-menu__label">{{ trans('Sidebar/Patient.Operations') }}</span><i class="angle fe fe-chevron-down"></i></a>
                 <ul class="slide-menu">
-                    <li><a class="slide-item" href="{{route('invoices.patient')}}">قائمة الفواتير</a></li>
-                    <li><a class="slide-item" href="{{route('records.patient')}}">الكشوفات</a></li>
-                    <li><a class="slide-item" href="{{route('laboratories.patient')}}">المختبر</a></li>
-                    <li><a class="slide-item" href="{{route('rays.patient')}}">الاشعة</a></li>
+                    <li><a class="slide-item" href="{{route('invoices.patient')}}">{{ trans('Sidebar/Patient.InvoicesList') }}</a></li>
+                    <li><a class="slide-item" href="{{route('records.patient')}}">{{ trans('Sidebar/Patient.Records') }}</a></li>
+                    <li><a class="slide-item" href="{{route('laboratories.patient')}}">{{ trans('Sidebar/Patient.Laboratory') }}</a></li>
+                    <li><a class="slide-item" href="{{route('rays.patient')}}">{{ trans('Sidebar/Patient.Rays') }}</a></li>
                 </ul>
             </li>
 
@@ -59,10 +59,10 @@ $folder = 'patients';
                         <path d="M0 0h24v24H0V0z" fill="none" />
                         <path d="M19 5H5v14h14V5zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z" opacity=".3" />
                         <path d="M3 5v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.1 0-2 .9-2 2zm2 0h14v14H5V5zm2 5h2v7H7zm4-3h2v10h-2zm4 6h2v4h-2z" />
-                    </svg><span class="side-menu__label">المواعيد</span><i class="angle fe fe-chevron-down"></i></a>
+                    </svg><span class="side-menu__label">{{ trans('Sidebar/Patient.Appointments') }}</span><i class="angle fe fe-chevron-down"></i></a>
                 <ul class="slide-menu">
-                    <li><a class="slide-item" href="{{ route('appointments.patient') }}">قائمة المواعيد</a></li>
-                    <li><a class="slide-item" href="{{ route('appointments.expired.patient') }}">المواعيد المنتهية</a></li>
+                    <li><a class="slide-item" href="{{ route('appointments.patient') }}">{{ trans('Sidebar/Patient.AppointmentsList') }}</a></li>
+                    <li><a class="slide-item" href="{{ route('appointments.expired.patient') }}">{{ trans('Sidebar/Patient.ExpiredAppointments') }}</a></li>
                 </ul>
             </li>
 
@@ -71,10 +71,10 @@ $folder = 'patients';
                         <path d="M0 0h24v24H0V0z" fill="none" />
                         <path d="M19 5H5v14h14V5zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z" opacity=".3" />
                         <path d="M3 5v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.1 0-2 .9-2 2zm2 0h14v14H5V5zm2 5h2v7H7zm4-3h2v10h-2zm4 6h2v4h-2z" />
-                    </svg><span class="side-menu__label">المحادثات</span><i class="angle fe fe-chevron-down"></i></a>
+                    </svg><span class="side-menu__label">{{ trans('Sidebar/Patient.Chats') }}</span><i class="angle fe fe-chevron-down"></i></a>
                 <ul class="slide-menu">
-                    <li><a class="slide-item" href="{{route('list.doctors')}}">قائمة الاطباء</a></li>
-                    <li><a class="slide-item" href="{{route('chat.doctors')}}">المحادثات الاخيرة</a></li>
+                    <li><a class="slide-item" href="{{route('list.doctors')}}">{{ trans('Sidebar/Patient.DoctorsList') }}</a></li>
+                    <li><a class="slide-item" href="{{route('chat.doctors')}}">{{ trans('Sidebar/Patient.RecentChats') }}</a></li>
                 </ul>
             </li> -->
         </ul>

--- a/resources/views/Dashboard/layouts/main-sidebar/ray_employee-sidebar-main.blade.php
+++ b/resources/views/Dashboard/layouts/main-sidebar/ray_employee-sidebar-main.blade.php
@@ -45,10 +45,10 @@ $folder = 'ray_employees';
 						<path d="M0 0h24v24H0V0z" fill="none" />
 						<path d="M19 5H5v14h14V5zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z" opacity=".3" />
 						<path d="M3 5v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.1 0-2 .9-2 2zm2 0h14v14H5V5zm2 5h2v7H7zm4-3h2v10h-2zm4 6h2v4h-2z" />
-					</svg><span class="side-menu__label">كشوفات الاشعة </span><i class="angle fe fe-chevron-down"></i></a>
+                                        </svg><span class="side-menu__label">{{ trans('Sidebar/RayEmployee.Invoices') }}</span><i class="angle fe fe-chevron-down"></i></a>
 				<ul class="slide-menu">
-					<li><a class="slide-item" href="{{ route('invoices_ray_employee.index') }}">قائمة الكشوفات</a></li>
-					<li><a class="slide-item" href="{{route('ray_completed_invoices')}}">قائمة الكشوفات المكتملة</a></li>
+                                        <li><a class="slide-item" href="{{ route('invoices_ray_employee.index') }}">{{ trans('Sidebar/RayEmployee.InvoicesList') }}</a></li>
+                                        <li><a class="slide-item" href="{{route('ray_completed_invoices')}}">{{ trans('Sidebar/RayEmployee.CompletedInvoices') }}</a></li>
 				</ul>
 			</li>
 		</ul>


### PR DESCRIPTION
## Summary
- Replace hardcoded sidebar labels with translation strings for doctor, patient, ray, and lab employees
- Add Arabic and English sidebar translation files with keys for invoices, appointments, chats, and related links

## Testing
- `composer install`
- `./vendor/bin/phpunit` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b61ae06f6883288575c589c234edd9