### PR TITLE
Localize dashboard layout strings

### DIFF
--- a/resources/lang/ar/Dashboard/Layouts.php
+++ b/resources/lang/ar/Dashboard/Layouts.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+    'Title' => 'برنامج ادارة المستشفيات',
+    'Loader' => 'جاري التحميل',
+    'MediaCenter' => 'مركز الإعلام',
+    'Notifications' => 'الإشعارات',
+    'NoNotifications' => 'لا توجد إشعارات',
+    'Online' => 'متصل',
+    'Offline' => 'غير متصل',
+];
+

--- a/resources/lang/en/Dashboard/Layouts.php
+++ b/resources/lang/en/Dashboard/Layouts.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+    'Title' => 'Hospital Management System',
+    'Loader' => 'Loading',
+    'MediaCenter' => 'Media Center',
+    'Notifications' => 'Notifications',
+    'NoNotifications' => 'No notifications',
+    'Online' => 'Online',
+    'Offline' => 'Offline',
+];
+

--- a/resources/views/Dashboard/layouts/footer-scripts.blade.php
+++ b/resources/views/Dashboard/layouts/footer-scripts.blade.php
@@ -72,8 +72,8 @@
       var dot = ind.querySelector('.status-dot');
       var text = document.getElementById('online-indicator-text');
       if(dot){ dot.style.background = isOffline ? '#dc3545' : '#28a745'; }
-      if(text){ text.textContent = isOffline ? 'غير متصل' : 'متصل'; }
-      ind.title = isOffline ? 'غير متصل' : 'متصل';
+      if(text){ text.textContent = isOffline ? "{{ trans('Dashboard/Layouts.Offline') }}" : "{{ trans('Dashboard/Layouts.Online') }}"; }
+      ind.title = isOffline ? "{{ trans('Dashboard/Layouts.Offline') }}" : "{{ trans('Dashboard/Layouts.Online') }}";
     }
   }
 

--- a/resources/views/Dashboard/layouts/master.blade.php
+++ b/resources/views/Dashboard/layouts/master.blade.php
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
-<title>برنامج ادارة المستشفيات</title>
+<title>{{ trans('Dashboard/Layouts.Title') }}</title>
 
 <head>
 	<meta charset="UTF-8">
@@ -15,7 +15,7 @@
 <body class="main-body app sidebar-mini">
 	<!-- Loader -->
 	<div id="global-loader">
-		<img src="{{URL::asset('Dashboard/img/loader.svg')}}" class="loader-img" alt="Loader">
+                <img src="{{URL::asset('Dashboard/img/loader.svg')}}" class="loader-img" alt="{{ trans('Dashboard/Layouts.Loader') }}">
 	</div>
 	<!-- /Loader -->
 	@include('Dashboard.layouts.main-sidebar')

--- a/resources/views/Dashboard/layouts/sidebar.blade.php
+++ b/resources/views/Dashboard/layouts/sidebar.blade.php
@@ -14,7 +14,7 @@ $notifications = $userId
 <div class="sidebar sidebar-left sidebar-animate">
 	<div class="panel panel-primary card mb-0 box-shadow">
 		<div class="tab-menu-heading border-0 p-3">
-			<div class="card-title mb-0">مركز الإعلام</div>
+                        <div class="card-title mb-0">{{ trans('Dashboard/Layouts.MediaCenter') }}</div>
 			<div class="card-options mr-auto">
 				<a href="#" class="sidebar-remove"><i class="fe fe-x"></i></a>
 			</div>
@@ -24,7 +24,7 @@ $notifications = $userId
 				<!-- Tabs -->
 				<ul class="nav panel-tabs">
 					<!-- <li class=""><a href="#side1" class="active" data-toggle="tab"><i class="ion ion-md-chatboxes tx-18 ml-2"></i> الدردشة</a></li> -->
-					<li><a href="#side2" data-toggle="tab"><i class="ion ion-md-notifications tx-18  ml-2"></i> الإشعارات</a></li>
+                                        <li><a href="#side2" data-toggle="tab"><i class="ion ion-md-notifications tx-18  ml-2"></i> {{ trans('Dashboard/Layouts.Notifications') }}</a></li>
 					<!-- <li><a href="#side3" data-toggle="tab"><i class="ion ion-md-contacts tx-18 ml-2"></i> Friends</a></li> -->
 				</ul>
 			</div>
@@ -178,9 +178,9 @@ $notifications = $userId
 							</div>
 						</div>
 						@empty
-						<div class="list-group-item text-center">
-							{{ __('لا توجد إشعارات') }}
-						</div>
+                                                <div class="list-group-item text-center">
+                                                        {{ trans('Dashboard/Layouts.NoNotifications') }}
+                                                </div>
 						@endforelse
 					</div>
 				</div>


### PR DESCRIPTION
## Summary
- use translation helper for dashboard title and loader
- localize sidebar labels and offline indicator
- add Arabic and English dashboard layout translations

## Testing
- `php -l resources/lang/ar/Dashboard/Layouts.php`
- `php -l resources/lang/en/Dashboard/Layouts.php`
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_68b61adf482c83288b5a7a100ed3af1a