### PR TITLE
Add Payment translation files and localize views

### DIFF
--- a/resources/lang/ar/Payment.php
+++ b/resources/lang/ar/Payment.php
@@ -1,0 +1,26 @@
+<?php
+
+return [
+    'PaymentVoucher' => 'سند صرف',
+    'PaymentVouchers' => 'سندات الصرف',
+    'AddVoucher' => 'اضافة سند صرف جديد',
+    'EditVoucher' => 'تعديل سند صرف',
+    'DeleteVoucher' => 'حذف سند صرف',
+    'Accounts' => 'الحسابات',
+    'PatientName' => 'اسم المريض',
+    'Amount' => 'المبلغ',
+    'Statement' => 'البيان',
+    'Notes' => 'ملاحظات',
+    'CreatedAt' => 'تاريخ الاضافة',
+    'Actions' => 'العمليات',
+    'Print' => 'طباعه سند صرف',
+    'PrintButton' => 'طباعه',
+    'VoucherInfo' => 'معلومات السند',
+    'IssueDate' => 'تاريخ الاصدار',
+    'Warning' => 'هل انت متاكد من عملية الحذف ؟',
+    'Close' => 'اغلاق',
+    'Confirm' => 'تاكيد',
+    'Submit' => 'حفظ البيانات',
+    'ProgramName' => 'برنامج ادراه المستشفي',
+    'UniversityName' => 'جامعة حلب الحرة',
+];

--- a/resources/lang/en/Payment.php
+++ b/resources/lang/en/Payment.php
@@ -1,0 +1,26 @@
+<?php
+
+return [
+    'PaymentVoucher' => 'Payment Voucher',
+    'PaymentVouchers' => 'Payment Vouchers',
+    'AddVoucher' => 'Add Voucher',
+    'EditVoucher' => 'Edit Voucher',
+    'DeleteVoucher' => 'Delete Voucher',
+    'Accounts' => 'Accounts',
+    'PatientName' => 'Patient Name',
+    'Amount' => 'Amount',
+    'Statement' => 'Statement',
+    'Notes' => 'Notes',
+    'CreatedAt' => 'Created At',
+    'Actions' => 'Actions',
+    'Print' => 'Print Payment Voucher',
+    'PrintButton' => 'Print',
+    'VoucherInfo' => 'Voucher Information',
+    'IssueDate' => 'Issue Date',
+    'Warning' => 'Are you sure about the deletion process?',
+    'Close' => 'Close',
+    'Confirm' => 'Confirm',
+    'Submit' => 'Save',
+    'ProgramName' => 'Hospital Management Program',
+    'UniversityName' => 'Free Aleppo University',
+];

--- a/resources/views/Dashboard/Payment/add.blade.php
+++ b/resources/views/Dashboard/Payment/add.blade.php
@@ -6,14 +6,14 @@
 @endsection
 
 @section('title')
-    اضافة سند صرف جديد
+    {{ trans('Payment.AddVoucher') }}
 @stop
 @section('page-header')
     <!-- breadcrumb -->
     <div class="breadcrumb-header justify-content-between">
         <div class="my-auto">
             <div class="d-flex">
-                <h4 class="content-title mb-0 my-auto">الحسابات</h4><span class="text-muted mt-1 tx-13 mr-2 mb-0">/ اضافة سند صرف جديد</span>
+                <h4 class="content-title mb-0 my-auto">{{ trans('Payment.Accounts') }}</h4><span class="text-muted mt-1 tx-13 mr-2 mb-0">/ {{ trans('Payment.AddVoucher') }}</span>
             </div>
         </div>
     </div>
@@ -33,7 +33,7 @@
 
                             <div class="row row-xs align-items-center mg-b-20">
                                 <div class="col-md-1">
-                                    <label>اسم المريض</label>
+                                    <label>{{ trans('Payment.PatientName') }}</label>
                                 </div>
                                 <div class="col-md-11 mg-t-5 mg-md-t-0">
                                    <select name="patient_id" class="form-control select2" required>
@@ -47,7 +47,7 @@
 
                             <div class="row row-xs align-items-center mg-b-20">
                                 <div class="col-md-1">
-                                    <label>المبلغ</label>
+                                    <label>{{ trans('Payment.Amount') }}</label>
                                 </div>
                                 <div class="col-md-11 mg-t-5 mg-md-t-0">
                                     <input class="form-control" name="credit" type="text" inputmode="decimal" pattern="[0-9,\.]*" oninput="this.value=this.value.replace(/[^0-9.,]/g,'');">
@@ -56,14 +56,14 @@
 
                             <div class="row row-xs align-items-center mg-b-20">
                                 <div class="col-md-1">
-                                    <label>البيان</label>
+                                    <label>{{ trans('Payment.Statement') }}</label>
                                 </div>
                                 <div class="col-md-11 mg-t-5 mg-md-t-0">
                                     <textarea class="form-control" name="description" rows="3"></textarea>
                                 </div>
                             </div>
 
-                            <button type="submit" class="btn btn-main-primary pd-x-30 mg-r-5 mg-t-5">{{ trans('Doctors.submit') }}</button>
+                            <button type="submit" class="btn btn-main-primary pd-x-30 mg-r-5 mg-t-5">{{ trans('Payment.Submit') }}</button>
                         </div>
                     </form>
                 </div>

--- a/resources/views/Dashboard/Payment/delete.blade.php
+++ b/resources/views/Dashboard/Payment/delete.blade.php
@@ -4,7 +4,7 @@
     <div class="modal-dialog" role="document">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title" id="exampleModalLabel">حذف سند صرف</h5>
+                <h5 class="modal-title" id="exampleModalLabel">{{ trans('Payment.DeleteVoucher') }}</h5>
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                     <span aria-hidden="true">&times;</span>
                 </button>
@@ -14,11 +14,11 @@
                 {{ csrf_field() }}
             <div class="modal-body">
                 <input type="hidden" name="id" value="{{ $payment->id }}">
-                <h5>{{trans('Dashboard/sections_trans.Warning')}}<span style="color: red"> {{ $payment->patients->name }}</span></h5>
+                <h5>{{ trans('Payment.Warning') }}<span style="color: red"> {{ $payment->patients->name }}</span></h5>
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-dismiss="modal">{{trans('Dashboard/sections_trans.Close')}}</button>
-                <button type="submit" class="btn btn-danger">{{trans('Dashboard/sections_trans.submit')}}</button>
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">{{ trans('Payment.Close') }}</button>
+                <button type="submit" class="btn btn-danger">{{ trans('Payment.Confirm') }}</button>
             </div>
             </form>
         </div>

--- a/resources/views/Dashboard/Payment/edit.blade.php
+++ b/resources/views/Dashboard/Payment/edit.blade.php
@@ -6,14 +6,14 @@
 @endsection
 
 @section('title')
-    تعديل سند قبض
+    {{ trans('Payment.EditVoucher') }}
 @stop
 @section('page-header')
     <!-- breadcrumb -->
     <div class="breadcrumb-header justify-content-between">
         <div class="my-auto">
             <div class="d-flex">
-                <h4 class="content-title mb-0 my-auto">الحسابات</h4><span class="text-muted mt-1 tx-13 mr-2 mb-0">/ تعديل سند قبض </span>
+                <h4 class="content-title mb-0 my-auto">{{ trans('Payment.Accounts') }}</h4><span class="text-muted mt-1 tx-13 mr-2 mb-0">/ {{ trans('Payment.EditVoucher') }} </span>
             </div>
         </div>
     </div>
@@ -34,7 +34,7 @@
 
                             <div class="row row-xs align-items-center mg-b-20">
                                 <div class="col-md-1">
-                                    <label>اسم المريض</label>
+                                    <label>{{ trans('Payment.PatientName') }}</label>
                                     <input class="form-control" value="{{$payment_accounts->id}}" name="id" type="hidden">
 
                                 </div>
@@ -49,7 +49,7 @@
 
                             <div class="row row-xs align-items-center mg-b-20">
                                 <div class="col-md-1">
-                                    <label>المبلغ</label>
+                                    <label>{{ trans('Payment.Amount') }}</label>
                                 </div>
                                 <div class="col-md-11 mg-t-5 mg-md-t-0">
                                     <input class="form-control" value="{{$payment_accounts->amount}}" name="credit" type="text" inputmode="decimal" pattern="[0-9,\.]*" oninput="this.value=this.value.replace(/[^0-9.,]/g,'');">
@@ -58,14 +58,14 @@
 
                             <div class="row row-xs align-items-center mg-b-20">
                                 <div class="col-md-1">
-                                    <label>البيان</label>
+                                    <label>{{ trans('Payment.Statement') }}</label>
                                 </div>
                                 <div class="col-md-11 mg-t-5 mg-md-t-0">
                                     <textarea class="form-control" name="description" rows="3">{{$payment_accounts->description}}</textarea>
                                 </div>
                             </div>
 
-                            <button type="submit" class="btn btn-main-primary pd-x-30 mg-r-5 mg-t-5">{{ trans('Doctors.submit') }}</button>
+                            <button type="submit" class="btn btn-main-primary pd-x-30 mg-r-5 mg-t-5">{{ trans('Payment.Submit') }}</button>
                         </div>
                     </form>
                 </div>

--- a/resources/views/Dashboard/Payment/index.blade.php
+++ b/resources/views/Dashboard/Payment/index.blade.php
@@ -1,6 +1,6 @@
 @extends('Dashboard.layouts.master')
 @section('title')
-    سندات الصرف
+    {{ trans('Payment.PaymentVouchers') }}
 @stop
 @section('css')
     <!-- Internal Data table css -->
@@ -21,7 +21,7 @@
 				<div class="breadcrumb-header justify-content-between">
 					<div class="my-auto">
 						<div class="d-flex">
-							<h4 class="content-title mb-0 my-auto">الحسابات</h4><span class="text-muted mt-1 tx-13 mr-2 mb-0">/ سندات الصرف</span>
+                                                        <h4 class="content-title mb-0 my-auto">{{ trans('Payment.Accounts') }}</h4><span class="text-muted mt-1 tx-13 mr-2 mb-0">/ {{ trans('Payment.PaymentVouchers') }}</span>
 						</div>
 					</div>
 				</div>
@@ -37,7 +37,7 @@
                                 <div class="card-header pb-0">
                                     <div class="d-flex justify-content-between">
                                         <a href="{{route('Payment.create')}}" class="btn btn-primary" role="button"
-                                           aria-pressed="true">اضافة سند جديد</a>
+                                           aria-pressed="true">{{ trans('Payment.AddVoucher') }}</a>
                                     </div>
                                 </div>
                                 <div class="card-body">
@@ -46,11 +46,11 @@
                                             <thead>
                                             <tr>
                                                 <th>#</th>
-                                                <th>اسم المريض</th>
-                                                <th>المبلغ</th>
-                                                <th>البيان</th>
-                                                <th>تاريخ الاضافة</th>
-                                                <th>العمليات</th>
+                                                <th>{{ trans('Payment.PatientName') }}</th>
+                                                <th>{{ trans('Payment.Amount') }}</th>
+                                                <th>{{ trans('Payment.Statement') }}</th>
+                                                <th>{{ trans('Payment.CreatedAt') }}</th>
+                                                <th>{{ trans('Payment.Actions') }}</th>
                                             </tr>
                                             </thead>
                                             <tbody>
@@ -64,7 +64,7 @@
                                                    <td>
                                                        <a href="{{route('Payment.edit',$payment->id)}}" class="btn btn-sm btn-primary"><i class="fas fa-edit"></i></a>
                                                        <a class="modal-effect btn btn-sm btn-danger" data-effect="effect-scale"  data-toggle="modal" href="#delete{{$payment->id}}"><i class="las la-trash"></i></a>
-                                                       <a href="{{route('Payment.show',$payment->id)}}" class="btn btn-primary btn-sm" target="_blank" title="طباعه سند صرف"><i class="fas fa-print"></i></a>
+                                                       <a href="{{route('Payment.show',$payment->id)}}" class="btn btn-primary btn-sm" target="_blank" title="{{ trans('Payment.Print') }}"><i class="fas fa-print"></i></a>
 
                                                    </td>
                                                </tr>

--- a/resources/views/Dashboard/Payment/print.blade.php
+++ b/resources/views/Dashboard/Payment/print.blade.php
@@ -1,6 +1,6 @@
 @extends('Dashboard.layouts.master')
 @section('title')
-    {{ trans('Dashboard/Payment.Title') }}
+    {{ trans('Payment.PaymentVoucher') }}
 @stop
 @section('css')
     <style>
@@ -16,7 +16,7 @@
     <div class="breadcrumb-header justify-content-between">
         <div class="my-auto">
             <div class="d-flex">
-                <h4 class="content-title mb-0 my-auto">{{ trans('Dashboard/Payment.Title') }}</h4><span class="text-muted mt-1 tx-13 mr-2 mb-0">/ {{ trans('Dashboard/Payment.BreadcrumbPrint') }}</span>
+                <h4 class="content-title mb-0 my-auto">{{ trans('Payment.PaymentVoucher') }}</h4><span class="text-muted mt-1 tx-13 mr-2 mb-0">/ {{ trans('Payment.Print') }}</span>
             </div>
         </div>
     </div>
@@ -30,19 +30,19 @@
                 <div class="card card-invoice">
                     <div class="card-body">
                         <div class="invoice-header">
-                            <h1 class="invoice-title">{{ trans('Dashboard/Payment.Title') }}</h1>
+                            <h1 class="invoice-title">{{ trans('Payment.PaymentVoucher') }}</h1>
                             <div class="billed-from">
-                                <h6>برنامج ادراه المستشفي </h6>
-                                <p>جامعة حلب الحرة<br>
+                                <h6>{{ trans('Payment.ProgramName') }} </h6>
+                                <p>{{ trans('Payment.UniversityName') }}<br>
                                     Tel No: 00905528779087<br>
                                     Email: info@moh.gov.sy</p>
                             </div><!-- billed-from -->
                         </div><!-- invoice-header -->
                         <div class="row mg-t-20">
                             <div class="col-md">
-                                <label class="tx-gray-600">{{ trans('Dashboard/Payment.VoucherInfo') }}</label>
-                                <p class="invoice-info-row"><span>{{ trans('Dashboard/Payment.IssueDate') }}</span> <span>{{$payment_account->date}}</span></p>
-                                <p class="invoice-info-row "><span>{{ trans('Dashboard/Payment.PatientName') }}</span> <span>{{$payment_account->patients->name}}</span></p>
+                                <label class="tx-gray-600">{{ trans('Payment.VoucherInfo') }}</label>
+                <p class="invoice-info-row"><span>{{ trans('Payment.IssueDate') }}</span> <span>{{$payment_account->date}}</span></p>
+                                <p class="invoice-info-row "><span>{{ trans('Payment.PatientName') }}</span> <span>{{$payment_account->patients->name}}</span></p>
                             </div>
                         </div>
                         <div class="table-responsive mg-t-40">
@@ -50,8 +50,8 @@
                                 <thead>
                                 <tr>
                                     <th class="wd-20p">#</th>
-                                    <th class="wd-40p">{{ trans('Dashboard/Payment.Notes') }}</th>
-                                    <th class="tx-center">{{ trans('Dashboard/Payment.Amount') }}</th>
+                                    <th class="wd-40p">{{ trans('Payment.Notes') }}</th>
+                                    <th class="tx-center">{{ trans('Payment.Amount') }}</th>
                                 </tr>
                                 </thead>
                                 <tbody>
@@ -65,7 +65,7 @@
                         </div>
                         <hr class="mg-b-40">
                         <a href="#" class="btn btn-danger float-left mt-3 mr-2" id="print_Button" onclick="printDiv()">
-                            <i class="mdi mdi-printer ml-1"></i>{{ trans('Dashboard/Payment.PrintButton') }}
+                            <i class="mdi mdi-printer ml-1"></i>{{ trans('Payment.PrintButton') }}
                         </a>
                     </div>
                 </div>

--- a/resources/views/livewire/group_invoices/Table.blade.php
+++ b/resources/views/livewire/group_invoices/Table.blade.php
@@ -36,7 +36,7 @@
                 <td>
                     <button wire:click="edit({{ $group_invoice->id }})" class="btn btn-primary btn-sm"><i class="fa fa-edit"></i></button>
                     <button type="button" class="btn btn-danger btn-sm" data-toggle="modal" data-target="#delete_invoice" wire:click="delete({{ $group_invoice->id }})" ><i class="fa fa-trash"></i></button>
-                    <a href="#"  wire:click="print({{ $group_invoice->id }})" class="btn btn-primary btn-sm" target="_blank" title="طباعه سند صرف"><i class="fas fa-print"></i></a>
+                    <a href="#"  wire:click="print({{ $group_invoice->id }})" class="btn btn-primary btn-sm" target="_blank" title="{{ trans('Payment.Print') }}"><i class="fas fa-print"></i></a>
                 </td>
             </tr>
 


### PR DESCRIPTION
## Summary
- add Payment translation files in Arabic and English
- localize payment views and modals to use translation keys
- reference translation for print buttons in group invoices

## Testing
- `./vendor/bin/phpunit` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b61ae1de4c8328a3584b7c9eb6ebea