### PR TITLE
Use translation key for section description label

### DIFF
--- a/resources/views/Dashboard/Sections/add.blade.php
+++ b/resources/views/Dashboard/Sections/add.blade.php
@@ -15,7 +15,7 @@
                     <input type="text" name="name" class="form-control">
                 </div>
                 <div class="modal-body">
-                    <label for="exampleInputPassword1">الوصف</label>
+                    <label for="exampleInputPassword1">{{ trans('sections_trans.description') }}</label>
                     <input type="text" name="description" class="form-control">
                 </div>
                 <div class="modal-footer">

--- a/resources/views/Dashboard/Sections/edit.blade.php
+++ b/resources/views/Dashboard/Sections/edit.blade.php
@@ -19,7 +19,7 @@
                     <input type="text" name="name" value="{{ $section->name }}" class="form-control">
                 </div>
                 <div class="modal-body">
-                    <label for="exampleInputPassword1">الوصف</label>
+                    <label for="exampleInputPassword1">{{ trans('sections_trans.description') }}</label>
                     <input type="text" name="description" value="{{$section->description}}" class="form-control">
                 </div>
                 <div class="modal-footer">


### PR DESCRIPTION
## Summary
- use translation key for "description" label in section add/edit modals

## Testing
- `./vendor/bin/phpunit --stop-on-error` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b622c71570832891fba02ac74b18c5