### PR TITLE
feat: add service translation files

### DIFF
--- a/resources/lang/ar/Dashboard/Services.php
+++ b/resources/lang/ar/Dashboard/Services.php
@@ -1,0 +1,15 @@
+<?php
+
+return [
+    'add_Service' => 'اضافة خدمة',
+    'delete_Service' => 'حذف خدمة',
+    'edit_Service' => 'تعديل خدمة',
+    'name' => 'الاسم',
+    'price' => 'سعر الخدمة',
+    'Status' => 'الحالة',
+    'Enabled' => 'مفعل',
+    'Not_enabled' => 'غير مفعل',
+    'description' => 'ملاحظات',
+    'created_at' => 'تاريخ الاضافة',
+    'Operations' => 'العمليات',
+];

--- a/resources/lang/en/Dashboard/Services.php
+++ b/resources/lang/en/Dashboard/Services.php
@@ -1,0 +1,15 @@
+<?php
+
+return [
+    'add_Service' => 'Add Service',
+    'delete_Service' => 'Delete Service',
+    'edit_Service' => 'Edit Service',
+    'name' => 'Name',
+    'price' => 'Price',
+    'Status' => 'Status',
+    'Enabled' => 'Enabled',
+    'Not_enabled' => 'Not enabled',
+    'description' => 'Description',
+    'created_at' => 'Created at',
+    'Operations' => 'Operations',
+];

--- a/resources/views/Dashboard/Services/Single Service/add.blade.php
+++ b/resources/views/Dashboard/Services/Single Service/add.blade.php
@@ -3,7 +3,7 @@
     <div class="modal-dialog" role="document">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title" id="exampleModalLabel">{{trans('Services.add_Service')}}</h5>
+                <h5 class="modal-title" id="exampleModalLabel">{{ trans('Dashboard/Services.add_Service') }}</h5>
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                     <span aria-hidden="true">&times;</span>
                 </button>
@@ -11,13 +11,13 @@
             <form action="{{ route('Service.store') }}" method="post" autocomplete="off">
                 @csrf
                 <div class="modal-body">
-                    <label for="name">{{trans('Services.name')}}</label>
+                    <label for="name">{{ trans('Dashboard/Services.name') }}</label>
                     <input type="text" name="name" id="name" class="form-control"><br>
 
-                    <label for="price">{{trans('Services.price')}}</label>
+                    <label for="price">{{ trans('Dashboard/Services.price') }}</label>
                     <input type="text" name="price" id="price" class="form-control" inputmode="decimal" pattern="[0-9,\.]*" oninput="this.value=this.value.replace(/[^0-9.,]/g,'');"><br>
 
-                    <label for="description">{{trans('Services.description')}}</label>
+                    <label for="description">{{ trans('Dashboard/Services.description') }}</label>
                     <textarea class="form-control" name="description" id="description" rows="5"></textarea>
                 </div>
 

--- a/resources/views/Dashboard/Services/Single Service/delete.blade.php
+++ b/resources/views/Dashboard/Services/Single Service/delete.blade.php
@@ -4,7 +4,7 @@
     <div class="modal-dialog" role="document">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title" id="exampleModalLabel">{{trans('Services.delete_Service')}}</h5>
+                <h5 class="modal-title" id="exampleModalLabel">{{ trans('Dashboard/Services.delete_Service') }}</h5>
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                     <span aria-hidden="true">&times;</span>
                 </button>

--- a/resources/views/Dashboard/Services/Single Service/edit.blade.php
+++ b/resources/views/Dashboard/Services/Single Service/edit.blade.php
@@ -4,7 +4,7 @@
     <div class="modal-dialog" role="document">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title" id="exampleModalLabel">{{trans('Services.edit_Service')}}</h5>
+                <h5 class="modal-title" id="exampleModalLabel">{{ trans('Dashboard/Services.edit_Service') }}</h5>
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                     <span aria-hidden="true">&times;</span>
                 </button>
@@ -14,23 +14,23 @@
                 {{ csrf_field() }}
                 @csrf
                 <div class="modal-body">
-                    <label for="name">{{trans('Services.name')}}</label>
+                    <label for="name">{{ trans('Dashboard/Services.name') }}</label>
                     <input type="text" name="name" id="name" value="{{$service->name}}" class="form-control"><br>
 
                     <input type="hidden" name="id" value="{{$service->id}}" class="form-control"><br>
 
-                    <label for="price">{{trans('Services.price')}}</label>
+                    <label for="price">{{ trans('Dashboard/Services.price') }}</label>
                     <input type="text" name="price" id="price" value="{{$service->price}}" class="form-control" inputmode="decimal" pattern="[0-9,\.]*" oninput="this.value=this.value.replace(/[^0-9.,]/g,'');"><br>
 
-                    <label for="description">{{trans('Services.description')}}</label>
+                    <label for="description">{{ trans('Dashboard/Services.description') }}</label>
                     <textarea class="form-control" name="description" id="description" rows="5">{{$service->description}}</textarea>
 
                     <div class="form-group">
-                        <label for="status">{{trans('doctors.Status')}}</label>
+                        <label for="status">{{ trans('Dashboard/Services.Status') }}</label>
                         <select class="form-control" id="status" name="status" required>
-                            <option value="{{$service->status}}" selected>{{$service->status == 1 ? trans('doctors.Enabled'):trans('doctors.Not_enabled')}}</option>
-                            <option value="1">{{trans('doctors.Enabled')}}</option>
-                            <option value="0">{{trans('doctors.Not_enabled')}}</option>
+                            <option value="{{$service->status}}" selected>{{$service->status == 1 ? trans('Dashboard/Services.Enabled'):trans('Dashboard/Services.Not_enabled')}}</option>
+                            <option value="1">{{ trans('Dashboard/Services.Enabled') }}</option>
+                            <option value="0">{{ trans('Dashboard/Services.Not_enabled') }}</option>
                         </select>
                     </div>
                 </div>

--- a/resources/views/Dashboard/Services/Single Service/index.blade.php
+++ b/resources/views/Dashboard/Services/Single Service/index.blade.php
@@ -28,7 +28,7 @@
                 <div class="card-header pb-0">
                     <div class="d-flex justify-content-between">
                         <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#add">
-                            {{trans('Services.add_Service')}}
+                            {{ trans('Dashboard/Services.add_Service') }}
                         </button>
                     </div>
                 </div>
@@ -38,12 +38,12 @@
                             <thead>
                             <tr>
                                 <th>#</th>
-                                <th> {{trans('Services.name')}}</th>
-                                <th> {{trans('Services.price')}}</th>
-                                <th> {{trans('doctors.Status')}}</th>
-                                <th> {{trans('Services.description')}}</th>
-                                <th>{{trans('sections_trans.created_at')}}</th>
-                                <th>{{trans('sections_trans.Processes')}}</th>
+                                <th> {{ trans('Dashboard/Services.name') }}</th>
+                                <th> {{ trans('Dashboard/Services.price') }}</th>
+                                <th> {{ trans('Dashboard/Services.Status') }}</th>
+                                <th> {{ trans('Dashboard/Services.description') }}</th>
+                                <th>{{ trans('Dashboard/Services.created_at') }}</th>
+                                <th>{{ trans('Dashboard/Services.Operations') }}</th>
                             </tr>
                             </thead>
                             <tbody>
@@ -55,7 +55,7 @@
                                     <td>
                                         <div
                                             class="dot-label bg-{{$service->status == 1 ? 'success':'danger'}} ml-1"></div>
-                                        {{$service->status == 1 ? trans('doctors.Enabled'):trans('doctors.Not_enabled')}}
+                                        {{$service->status == 1 ? trans('Dashboard/Services.Enabled'):trans('Dashboard/Services.Not_enabled')}}
                                     </td>
                                     <td> {{ Str::limit($service->description, 50) }}</td>
                                     <td>{{ $service->created_at->diffForHumans() }}</td>


### PR DESCRIPTION
## Summary
- add dedicated English and Arabic translation files for dashboard services
- update service views to reference the new dashboard/service keys

## Testing
- `php -l resources/lang/en/Dashboard/Services.php`
- `php -l resources/lang/ar/Dashboard/Services.php`
- `./vendor/bin/phpunit` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b622c790408328b52a916336fe9017